### PR TITLE
support pattern based multiple resource specification in verify-resource command

### DIFF
--- a/cmd/kubectl-sigstore/apply_after_verify.go
+++ b/cmd/kubectl-sigstore/apply_after_verify.go
@@ -33,6 +33,7 @@ func NewCmdApplyAfterVerify() *cobra.Command {
 	var imageRef string
 	var filename string
 	var keyPath string
+	var configPath string
 	cmd := &cobra.Command{
 		Use:   "apply-after-verify -f <YAMLFILE> [-i <IMAGE>]",
 		Short: "A command to apply Kubernetes YAML manifests only after verifying signature",
@@ -42,7 +43,7 @@ func NewCmdApplyAfterVerify() *cobra.Command {
 			if filename != "" {
 				kubeApplyArgs = append(kubeApplyArgs, []string{"--filename", filename}...)
 			}
-			err := applyAfterVerify(filename, imageRef, keyPath, kubeApplyArgs)
+			err := applyAfterVerify(filename, imageRef, keyPath, configPath, kubeApplyArgs)
 			if err != nil {
 				return err
 			}
@@ -54,11 +55,12 @@ func NewCmdApplyAfterVerify() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&filename, "filename", "f", "", "file name which will be signed (if dir, all YAMLs inside it will be signed)")
 	cmd.PersistentFlags().StringVarP(&imageRef, "image", "i", "", "signed image name which bundles yaml files")
 	cmd.PersistentFlags().StringVarP(&keyPath, "key", "k", "", "path to your signing key (if empty, do key-less signing)")
+	cmd.PersistentFlags().StringVarP(&configPath, "config", "c", "", "path to verification config YAML file (for advanced verification)")
 
 	return cmd
 }
 
-func applyAfterVerify(filename, imageRef, keyPath string, kubeApplyArgs []string) error {
+func applyAfterVerify(filename, imageRef, keyPath, configPath string, kubeApplyArgs []string) error {
 	manifest, err := ioutil.ReadFile(filename)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
@@ -73,7 +75,22 @@ func applyAfterVerify(filename, imageRef, keyPath string, kubeApplyArgs []string
 	log.Debug("annotations", annotations)
 	log.Debug("imageRef", imageRef)
 
-	result, err := k8smanifest.Verify(manifest, imageRef, keyPath)
+	vo := &k8smanifest.VerifyManifestOption{}
+	if configPath != "" {
+		vo, err = k8smanifest.LoadVerifyManifestConfig(configPath)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err.Error())
+			return nil
+		}
+	}
+	if imageRef != "" {
+		vo.ImageRef = imageRef
+	}
+	if keyPath != "" {
+		vo.KeyPath = keyPath
+	}
+
+	result, err := k8smanifest.VerifyManifest(manifest, vo)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		return nil
@@ -114,20 +131,25 @@ func getOriginalFullArgs(separator string) []string {
 func splitApplyArgs(args []string) ([]string, []string) {
 	mainArgs := []string{}
 	kubectlArgs := []string{}
-	mainArgsCondition := map[string]bool{
+	mainArgsConditionSingle := map[string]bool{}
+	mainArgsConditionDouble := map[string]bool{
 		"--filename": true,
 		"-f":         true,
 		"--image":    true,
 		"-i":         true,
 		"--key":      true,
 		"-k":         true,
+		"--config":   true,
+		"-c":         true,
 	}
 	skipIndex := map[int]bool{}
 	for i, s := range args {
 		if skipIndex[i] {
 			continue
 		}
-		if mainArgsCondition[s] {
+		if mainArgsConditionSingle[s] {
+			mainArgs = append(mainArgs, args[i])
+		} else if mainArgsConditionDouble[s] {
 			mainArgs = append(mainArgs, args[i])
 			mainArgs = append(mainArgs, args[i+1])
 			skipIndex[i+1] = true

--- a/cmd/kubectl-sigstore/main.go
+++ b/cmd/kubectl-sigstore/main.go
@@ -28,7 +28,7 @@ func init() {
 	rootCmd.AddCommand(NewCmdVerifyResource())
 	rootCmd.AddCommand(NewCmdApplyAfterVerify())
 
-	log.SetLevel(log.InfoLevel)
+	log.SetLevel(log.DebugLevel)
 }
 
 func main() {

--- a/cmd/kubectl-sigstore/sign.go
+++ b/cmd/kubectl-sigstore/sign.go
@@ -55,11 +55,18 @@ func NewCmdSign() *cobra.Command {
 }
 
 func sign(inputDir, imageRef, keyPath, output string, updateAnnotation bool) error {
-	if output == "" {
+	if output == "" && updateAnnotation {
 		output = inputDir + ".signed"
 	}
 
-	_, err := k8smanifest.Sign(inputDir, imageRef, keyPath, output, updateAnnotation)
+	so := &k8smanifest.SignOption{
+		ImageRef:         imageRef,
+		KeyPath:          keyPath,
+		Output:           output,
+		UpdateAnnotation: updateAnnotation,
+	}
+
+	_, err := k8smanifest.Sign(inputDir, so)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		return nil

--- a/pkg/cosign/sign.go
+++ b/pkg/cosign/sign.go
@@ -22,9 +22,6 @@ import (
 	cosigncli "github.com/sigstore/cosign/cmd/cosign/cli"
 )
 
-const certBeginByte = "-----BEGIN CERTIFICATE-----"
-const certEndByte = "-----END CERTIFICATE-----"
-
 func SignImage(imageRef string, keyPath *string) error {
 	// TODO: check usecase for yaml signing
 	imageAnnotation := map[string]interface{}{}

--- a/pkg/cosign/sign.go
+++ b/pkg/cosign/sign.go
@@ -1,0 +1,50 @@
+//
+// Copyright 2020 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cosign
+
+import (
+	"context"
+
+	cosigncli "github.com/sigstore/cosign/cmd/cosign/cli"
+)
+
+const certBeginByte = "-----BEGIN CERTIFICATE-----"
+const certEndByte = "-----END CERTIFICATE-----"
+
+func SignImage(imageRef string, keyPath *string) error {
+	// TODO: check usecase for yaml signing
+	imageAnnotation := map[string]interface{}{}
+
+	// TODO: check sk (security key) and idToken (identity token for cert from fulcio)
+	sk := false
+	idToken := ""
+
+	// TODO: handle the case that COSIGN_EXPERIMENTAL env var is not set
+
+	opt := cosigncli.SignOpts{
+		Annotations: imageAnnotation,
+		Sk:          sk,
+		IDToken:     idToken,
+	}
+
+	if keyPath != nil {
+		opt.KeyRef = *keyPath
+		opt.Pf = cosigncli.GetPass
+	}
+
+	return cosigncli.SignCmd(context.Background(), opt, imageRef, true, "", false, false)
+}

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1,0 +1,83 @@
+//
+// Copyright 2020 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cosign
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/go-containerregistry/pkg/name"
+
+	"github.com/sigstore/cosign/cmd/cosign/cli"
+	"github.com/sigstore/cosign/pkg/cosign"
+	"github.com/sigstore/cosign/pkg/cosign/fulcio"
+	k8smnfutil "github.com/sigstore/k8s-manifest-sigstore/pkg/util"
+	"github.com/sigstore/sigstore/pkg/signature/payload"
+)
+
+const (
+	tmpMessageFile     = "k8s-manifest-sigstore-message"
+	tmpCertificateFile = "k8s-manifest-sigstore-certificate"
+	tmpSignatureFile   = "k8s-manifest-sigstore-signature"
+)
+
+func VerifyImage(imageRef string, pubkeyPath *string) (bool, string, error) {
+	ref, err := name.ParseReference(imageRef)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to parse image ref `%s`; %s", imageRef, err.Error())
+	}
+
+	co := &cosign.CheckOpts{
+		Claims: true,
+		Tlog:   true,
+		Roots:  fulcio.Roots,
+	}
+
+	if pubkeyPath != nil && *pubkeyPath != "" {
+		tmpPubkey, err := cosign.LoadPublicKey(context.Background(), *pubkeyPath)
+		if err != nil {
+			return false, "", fmt.Errorf("error loading public key; %s", err.Error())
+		}
+		co.PubKey = tmpPubkey
+	}
+
+	rekorSever := cli.TlogServer()
+	verified, err := cosign.Verify(context.Background(), ref, co, rekorSever)
+	if err != nil {
+		return false, "", fmt.Errorf("error occured while verifying image `%s`; %s", imageRef, err.Error())
+	}
+	if len(verified) == 0 {
+		return false, "", fmt.Errorf("no verified signatures in the image `%s`; %s", imageRef, err.Error())
+	}
+	var cert *x509.Certificate
+	for _, vp := range verified {
+		ss := payload.SimpleContainerImage{}
+		err := json.Unmarshal(vp.Payload, &ss)
+		if err != nil {
+			continue
+		}
+		cert = vp.Cert
+		break
+	}
+	signerName := "" // singerName could be empty in case of key-used verification
+	if cert != nil {
+		signerName = k8smnfutil.GetNameInfoFromCert(cert)
+	}
+	return true, signerName, nil
+}

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -31,12 +31,6 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature/payload"
 )
 
-const (
-	tmpMessageFile     = "k8s-manifest-sigstore-message"
-	tmpCertificateFile = "k8s-manifest-sigstore-certificate"
-	tmpSignatureFile   = "k8s-manifest-sigstore-signature"
-)
-
 func VerifyImage(imageRef string, pubkeyPath *string) (bool, string, error) {
 	ref, err := name.ParseReference(imageRef)
 	if err != nil {

--- a/pkg/k8smanifest/resources/known-changes.yaml
+++ b/pkg/k8smanifest/resources/known-changes.yaml
@@ -1,0 +1,23 @@
+ignoreFields:
+  - fields:
+    - metadata.managedFields.*
+    - metadata.resourceVersion
+    - metadata.selfLink
+    - metadata.annotations.kubectl.kubernetes.io/last-applied-configuration
+    objects:
+    - kind: '*'
+  - fields:
+    - secrets.*.name
+    - imagePullSecrets.*.name
+    objects:
+    - kind: ServiceAccount
+  - fields:
+    - spec.ports.*.nodePort
+    - spec.clusterIP
+    - spec.clusterIPs.0
+    objects:
+    - kind: Service
+  - fields:
+    - metadata.annotations.deployment.kubernetes.io/revision
+    objects:
+    - kind: Deployment

--- a/pkg/k8smanifest/sign.go
+++ b/pkg/k8smanifest/sign.go
@@ -18,7 +18,6 @@ package k8smanifest
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -28,56 +27,94 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	k8scosign "github.com/sigstore/k8s-manifest-sigstore/pkg/cosign"
 	k8ssigutil "github.com/sigstore/k8s-manifest-sigstore/pkg/util"
 	"github.com/sigstore/k8s-manifest-sigstore/pkg/util/mapnode"
 
-	cosigncli "github.com/sigstore/cosign/cmd/cosign/cli"
 	cremote "github.com/sigstore/cosign/pkg/cosign/remote"
 )
 
 const (
 	ImageRefAnnotationKey    = "cosign.sigstore.dev/imageRef"
-	SignatureAnnotationKey   = "cosign.sigstore.dev/siganture"
+	SignatureAnnotationKey   = "cosign.sigstore.dev/signature"
 	CertificateAnnotationKey = "cosign.sigstore.dev/certificate"
 	MessageAnnotationKey     = "cosign.sigstore.dev/message"
-	BundleAnnotationKey      = "cosign.sigstore.dev/bundle"
+	BundleAnnotationKey      = "cosign.sigstore.dev/bundle" // bundle is not supported in cosign.SignBlob() so far
 )
 
-func Sign(inputDir, imageRef, keyPath, output string, updateAnnotation bool) ([]byte, error) {
+var annotationKeyMap = map[string]string{
+	"signature":   SignatureAnnotationKey,
+	"certificate": CertificateAnnotationKey,
+	"message":     MessageAnnotationKey,
+	"bundle":      BundleAnnotationKey,
+	"imageRef":    ImageRefAnnotationKey,
+}
+
+func Sign(inputDir string, so *SignOption) ([]byte, error) {
+
+	output := ""
+	if so.UpdateAnnotation {
+		output = so.Output
+	}
+
+	signedBytes, err := NewSigner(so.ImageRef, so.KeyPath).Sign(inputDir, output)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to sign the specified content")
+	}
+
+	return signedBytes, nil
+}
+
+type Signer interface {
+	Sign(inputDir, output string) ([]byte, error)
+}
+
+func NewSigner(imageRef, keyPath string) Signer {
+	var prikeyPath *string
+	if keyPath != "" {
+		prikeyPath = &keyPath
+	}
+	if imageRef == "" {
+		// TODO: support annotation signature
+		return nil
+	} else {
+		return &ImageSigner{imageRef: imageRef, prikeyPath: prikeyPath}
+	}
+}
+
+type ImageSigner struct {
+	imageRef   string
+	prikeyPath *string
+}
+
+func (s *ImageSigner) Sign(inputDir, output string) ([]byte, error) {
 	var inputDataBuffer bytes.Buffer
 	err := k8ssigutil.TarGzCompress(inputDir, &inputDataBuffer)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to compress an input file/dir")
 	}
 	var signedBytes []byte
-
-	if imageRef != "" {
-		// upload files as image
-		err := uploadFileToRegistry(inputDataBuffer.Bytes(), imageRef)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to upload image with manifest")
-		}
-		// sign the image
-		err = signImage(imageRef, keyPath)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to sign image")
-		}
-		if updateAnnotation {
-			// generate a signed YAML file
-			signedBytes, err = generateSignedYAMLManifest(inputDir, imageRef, nil)
-			if err != nil {
-				return nil, errors.Wrap(err, "failed to generate a signed YAML")
-			}
-			err = ioutil.WriteFile(output, signedBytes, 0644)
-			if err != nil {
-				return nil, errors.Wrap(err, "failed to write a signed YAML into")
-			}
-		}
-	} else {
-		// TODO: support annotation signature instead of error
-		return nil, errors.New("imageRef is empty")
+	// upload files as image
+	err = uploadFileToRegistry(inputDataBuffer.Bytes(), s.imageRef)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to upload image with manifest")
 	}
-
+	// sign the image
+	err = k8scosign.SignImage(s.imageRef, s.prikeyPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to sign image")
+	}
+	if output != "" {
+		// generate a signed YAML file
+		signedBytes, err = generateSignedYAMLManifest(inputDir, s.imageRef, nil)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to generate a signed YAML")
+		}
+		err = ioutil.WriteFile(output, signedBytes, 0644)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to write a signed YAML into")
+		}
+	}
 	return signedBytes, nil
 }
 
@@ -110,30 +147,6 @@ func uploadFileToRegistry(inputData []byte, imageRef string) error {
 	return nil
 }
 
-func signImage(imageRef, keyPath string) error {
-	// TODO: check usecase for yaml signing
-	imageAnnotation := map[string]interface{}{}
-
-	// TODO: check sk (security key) and idToken (identity token for cert from fulcio)
-	sk := false
-	idToken := ""
-
-	// TODO: handle the case that COSIGN_EXPERIMENTAL env var is not set
-
-	opt := cosigncli.SignOpts{
-		Annotations: imageAnnotation,
-		Sk:          sk,
-		IDToken:     idToken,
-	}
-
-	if keyPath != "" {
-		opt.KeyRef = keyPath
-		opt.Pf = cosigncli.GetPass
-	}
-
-	return cosigncli.SignCmd(context.Background(), opt, imageRef, true, "", false, false)
-}
-
 func generateSignedYAMLManifest(inputDir, imageRef string, sigMaps map[string][]byte) ([]byte, error) {
 	if imageRef == "" && len(sigMaps) == 0 {
 		return nil, errors.New("either image ref or signature infos are required for generating a signed YAML")
@@ -148,7 +161,6 @@ func generateSignedYAMLManifest(inputDir, imageRef string, sigMaps map[string][]
 	if imageRef != "" {
 		annotationMap[ImageRefAnnotationKey] = imageRef
 	}
-	// TODO: support annotation signature
 
 	signedYAMLs := [][]byte{}
 	sumErr := []string{}

--- a/pkg/k8smanifest/sign.go
+++ b/pkg/k8smanifest/sign.go
@@ -42,14 +42,6 @@ const (
 	BundleAnnotationKey      = "cosign.sigstore.dev/bundle" // bundle is not supported in cosign.SignBlob() so far
 )
 
-var annotationKeyMap = map[string]string{
-	"signature":   SignatureAnnotationKey,
-	"certificate": CertificateAnnotationKey,
-	"message":     MessageAnnotationKey,
-	"bundle":      BundleAnnotationKey,
-	"imageRef":    ImageRefAnnotationKey,
-}
-
 func Sign(inputDir string, so *SignOption) ([]byte, error) {
 
 	output := ""

--- a/pkg/k8smanifest/verify_manifest.go
+++ b/pkg/k8smanifest/verify_manifest.go
@@ -1,0 +1,118 @@
+//
+// Copyright 2020 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package k8smanifest
+
+import (
+	"github.com/ghodss/yaml"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	k8ssigutil "github.com/sigstore/k8s-manifest-sigstore/pkg/util"
+	mapnode "github.com/sigstore/k8s-manifest-sigstore/pkg/util/mapnode"
+)
+
+func VerifyManifest(manifest []byte, vo *VerifyManifestOption) (*VerifyResult, error) {
+	if manifest == nil {
+		return nil, errors.New("input YAML manifest must be non-empty")
+	}
+
+	var obj unstructured.Unstructured
+	_ = yaml.Unmarshal(manifest, &obj)
+
+	verified := false
+	signerName := ""
+	var err error
+
+	// get ignore fields configuration for this resource if found
+	ignoreFields := []string{}
+	if vo != nil {
+		if ok, fields := vo.IgnoreFields.Match(obj); ok {
+			ignoreFields = fields
+		}
+	}
+
+	var manifestInRef []byte
+	manifestInRef, err = NewManifestFetcher(vo.ImageRef).Fetch(manifest)
+	if err != nil {
+		return nil, errors.Wrap(err, "reference YAML manifest not found for this manifest")
+	}
+
+	mnfMatched, diff, err := matchManifest(manifest, manifestInRef, ignoreFields)
+	if err != nil {
+		return nil, errors.Wrap(err, "error occurred during matching manifest")
+	}
+
+	var keyPath *string
+	if vo.KeyPath != "" {
+		keyPath = &(vo.KeyPath)
+	}
+
+	sigVerified, signerName, err := NewSignatureVerifier(manifest, vo.ImageRef, keyPath).Verify()
+	if err != nil {
+		return nil, errors.Wrap(err, "error occured during signature verification")
+	}
+
+	verified = mnfMatched && sigVerified && vo.Signers.Match(signerName)
+
+	return &VerifyResult{
+		Verified: verified,
+		Signer:   signerName,
+		Diff:     diff,
+	}, nil
+}
+
+func matchManifest(manifest, manifestInRef []byte, ignoreFields []string) (bool, *mapnode.DiffResult, error) {
+	log.Debug("manifest:", string(manifest))
+	log.Debug("manifest in reference:", string(manifestInRef))
+	inputFileNode, err := mapnode.NewFromYamlBytes(manifest)
+	if err != nil {
+		return false, nil, err
+	}
+	maskedInputNode := inputFileNode.Mask(EmbeddedAnnotationMaskKeys)
+
+	var obj unstructured.Unstructured
+	err = yaml.Unmarshal(manifest, &obj)
+	if err != nil {
+		return false, nil, err
+	}
+	apiVersion := obj.GetAPIVersion()
+	kind := obj.GetKind()
+	name := obj.GetName()
+	namespace := obj.GetNamespace()
+	found, foundBytes := k8ssigutil.FindSingleYaml(manifestInRef, apiVersion, kind, name, namespace)
+	if !found {
+		return false, nil, errors.New("failed to find the YAML manifest")
+	}
+	manifestNode, err := mapnode.NewFromYamlBytes(foundBytes)
+	if err != nil {
+		return false, nil, err
+	}
+	maskedManifestNode := manifestNode.Mask(EmbeddedAnnotationMaskKeys)
+	var matched bool
+	diff := maskedInputNode.Diff(maskedManifestNode)
+
+	// filter out ignoreFields
+	if diff != nil && len(ignoreFields) > 0 {
+		_, diff, _ = diff.Filter(ignoreFields)
+	}
+	if diff == nil || diff.Size() == 0 {
+		matched = true
+		diff = nil
+	}
+	return matched, diff, nil
+}

--- a/pkg/k8smanifest/verify_resource.go
+++ b/pkg/k8smanifest/verify_resource.go
@@ -20,11 +20,11 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	v1 "github.com/google/go-containerregistry/pkg/v1"
 	k8ssigutil "github.com/sigstore/k8s-manifest-sigstore/pkg/util"
 	kubeutil "github.com/sigstore/k8s-manifest-sigstore/pkg/util/kubeutil"
 	mapnode "github.com/sigstore/k8s-manifest-sigstore/pkg/util/mapnode"
@@ -63,18 +63,21 @@ func (r *VerifyResourceResult) String() string {
 	return string(rB)
 }
 
-func VerifyResource(obj unstructured.Unstructured, imageRef, keyPath string, vo *VerifyOption) (*VerifyResourceResult, error) {
+func VerifyResource(obj unstructured.Unstructured, vo *VerifyResourceOption) (*VerifyResourceResult, error) {
+
+	objBytes, _ := yaml.Marshal(obj.Object)
 
 	verified := false
 	inScope := true // assume that input resource is in scope in verify-resource
 	signerName := ""
+	var err error
 
 	// if imageRef is not specified in args and it is found in object annotations, use the found image ref
-	if imageRef == "" {
+	if vo.ImageRef == "" {
 		annotations := obj.GetAnnotations()
 		annoImageRef, found := annotations[ImageRefAnnotationKey]
 		if found {
-			imageRef = annoImageRef
+			vo.ImageRef = annoImageRef
 		}
 	}
 
@@ -93,63 +96,53 @@ func VerifyResource(obj unstructured.Unstructured, imageRef, keyPath string, vo 
 		}
 	}
 
-	// do manifest matching and signature verification
-	// TODO: support directly attached annotation sigantures
-	if imageRef != "" {
-		image, err := k8ssigutil.PullImage(imageRef)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to pull image")
-		}
-		ok, tmpDiff, err := matchResourceWithManifest(obj, image, ignoreFields)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to match resource with manifest")
-		}
-		if !ok {
-			return &VerifyResourceResult{
-				Verified: false,
-				InScope:  inScope,
-				Signer:   "",
-				Diff:     tmpDiff,
-			}, nil
-		}
-		verified, signerName, err = imageVerify(imageRef, &keyPath)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to verify image")
-		}
-		if verified {
-			if !vo.Signers.Match(signerName) {
-				verified = false
-			}
-		}
+	var manifestInRef []byte
+	manifestInRef, err = NewManifestFetcher(vo.ImageRef).Fetch(objBytes)
+	if err != nil {
+		return nil, errors.Wrap(err, "YAML manifest not found for this resource")
 	}
+
+	mnfMatched, diff, err := matchResourceWithManifest(obj, manifestInRef, ignoreFields, vo.CheckDryRunForApply)
+	if err != nil {
+		return nil, errors.Wrap(err, "error occurred during matching manifest")
+	}
+
+	var keyPath *string
+	if vo.KeyPath != "" {
+		keyPath = &(vo.KeyPath)
+	}
+
+	sigVerified, signerName, err := NewSignatureVerifier(objBytes, vo.ImageRef, keyPath).Verify()
+	if err != nil {
+		return nil, errors.Wrap(err, "error occured during signature verification")
+	}
+
+	verified = mnfMatched && sigVerified && vo.Signers.Match(signerName)
 
 	return &VerifyResourceResult{
 		Verified: verified,
 		InScope:  inScope,
 		Signer:   signerName,
+		Diff:     diff,
 	}, nil
-
 }
 
-func matchResourceWithManifest(obj unstructured.Unstructured, image v1.Image, ignoreFields []string) (bool, *mapnode.DiffResult, error) {
+func matchResourceWithManifest(obj unstructured.Unstructured, manifestInImage []byte, ignoreFields []string, checkDryRunForApply bool) (bool, *mapnode.DiffResult, error) {
 
 	apiVersion := obj.GetAPIVersion()
 	kind := obj.GetKind()
 	name := obj.GetName()
 	namespace := obj.GetNamespace()
 
-	concatYAMLFromImage, err := k8ssigutil.GenerateConcatYAMLsFromImage(image)
-	if err != nil {
-		return false, nil, err
-	}
 	log.Debug("obj: apiVersion", apiVersion, "kind", kind, "name", name)
-	log.Debug("manifest in image:", string(concatYAMLFromImage))
+	log.Debug("manifest in image:", string(manifestInImage))
 
-	found, foundBytes := k8ssigutil.FindSingleYaml(concatYAMLFromImage, apiVersion, kind, name, namespace)
+	found, foundBytes := k8ssigutil.FindSingleYaml(manifestInImage, apiVersion, kind, name, namespace)
 	if !found {
 		return false, nil, errors.New("failed to find the corresponding manifest YAML file in image")
 	}
 
+	var err error
 	var matched bool
 	var diff *mapnode.DiffResult
 	objBytes, _ := json.Marshal(obj.Object)
@@ -164,7 +157,7 @@ func matchResourceWithManifest(obj unstructured.Unstructured, image v1.Image, ig
 	}
 
 	// CASE2: dryrun create match
-	matched, _, err = dryrunCreateMatch(objBytes, foundBytes)
+	matched, diff, err = dryrunCreateMatch(objBytes, foundBytes)
 	if err != nil {
 		return false, nil, errors.Wrap(err, "error occured during dryrun create match")
 	}
@@ -173,13 +166,16 @@ func matchResourceWithManifest(obj unstructured.Unstructured, image v1.Image, ig
 	}
 
 	// CASE3: dryrun apply match
-	matched, diff, err = dryrunApplyMatch(objBytes, foundBytes)
-	if err != nil {
-		return false, nil, errors.Wrap(err, "error occured during dryrun apply match")
+	if checkDryRunForApply {
+		matched, diff, err = dryrunApplyMatch(objBytes, foundBytes)
+		if err != nil {
+			return false, nil, errors.Wrap(err, "error occured during dryrun apply match")
+		}
+		if matched {
+			return true, nil, nil
+		}
 	}
-	if matched {
-		return true, nil, nil
-	}
+
 	// TODO: handle patch case
 	// // CASE4: dryrun patch match
 	// matched, diff, err = dryrunPatchMatch(objBytes, foundBytes)

--- a/pkg/k8smanifest/verify_resource.go
+++ b/pkg/k8smanifest/verify_resource.go
@@ -52,11 +52,10 @@ var CommonResourceMaskKeys = []string{
 }
 
 type VerifyResourceResult struct {
-	Object   unstructured.Unstructured `json:"-"`
-	Verified bool                      `json:"verified"`
-	InScope  bool                      `json:"inScope"`
-	Signer   string                    `json:"signer"`
-	Diff     *mapnode.DiffResult       `json:"diff"`
+	Verified bool                `json:"verified"`
+	InScope  bool                `json:"inScope"`
+	Signer   string              `json:"signer"`
+	Diff     *mapnode.DiffResult `json:"diff"`
 }
 
 func (r *VerifyResourceResult) String() string {
@@ -107,7 +106,6 @@ func VerifyResource(obj unstructured.Unstructured, imageRef, keyPath string, vo 
 		}
 		if !ok {
 			return &VerifyResourceResult{
-				Object:   obj,
 				Verified: false,
 				InScope:  inScope,
 				Signer:   "",
@@ -126,7 +124,6 @@ func VerifyResource(obj unstructured.Unstructured, imageRef, keyPath string, vo 
 	}
 
 	return &VerifyResourceResult{
-		Object:   obj,
 		Verified: verified,
 		InScope:  inScope,
 		Signer:   signerName,

--- a/pkg/util/cache.go
+++ b/pkg/util/cache.go
@@ -1,0 +1,80 @@
+//
+// Copyright 2020 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package util
+
+import (
+	"fmt"
+	"time"
+)
+
+var _ Cache = &OnMemoryCache{}
+
+type Cache interface {
+	Set(key string, value ...interface{}) error
+	Get(key string) ([]interface{}, error)
+}
+
+type cachedObject struct {
+	timestamp time.Time
+	object    []interface{}
+}
+
+type OnMemoryCache struct {
+	TTL  time.Duration
+	data map[string]cachedObject
+}
+
+func (c *OnMemoryCache) Set(key string, value ...interface{}) error {
+	if c.data == nil {
+		c.data = map[string]cachedObject{}
+	}
+
+	c.data[key] = cachedObject{
+		timestamp: time.Now().UTC(),
+		object:    value,
+	}
+	return nil
+}
+
+func (c *OnMemoryCache) Get(key string) ([]interface{}, error) {
+	if c.data == nil {
+		c.data = map[string]cachedObject{}
+	}
+	c.clearExpiredData()
+
+	obj, ok := c.data[key]
+	if !ok {
+		return nil, fmt.Errorf("no cached data is found with key `%s`", key)
+	}
+	return obj.object, nil
+}
+
+func (c *OnMemoryCache) clearExpiredData() {
+	if c.data == nil {
+		c.data = map[string]cachedObject{}
+	}
+
+	newData := map[string]cachedObject{}
+	for key, obj := range c.data {
+		now := time.Now().UTC()
+		if now.Sub(obj.timestamp) > c.TTL {
+			continue
+		}
+		newData[key] = obj
+	}
+	c.data = newData
+}

--- a/pkg/util/image.go
+++ b/pkg/util/image.go
@@ -73,7 +73,7 @@ func GenerateConcatYAMLsFromImage(img v1.Image) ([]byte, error) {
 			continue
 		}
 		blobStream := bytes.NewBuffer(blob)
-		yamlsInLayer, err := getYAMLsInArtifact(blobStream)
+		yamlsInLayer, err := GetYAMLsInArtifact(blobStream)
 		if err != nil {
 			sumErr = append(sumErr, errors.Wrap(err, "failed to decompress tar gz blob").Error())
 			continue
@@ -87,7 +87,7 @@ func GenerateConcatYAMLsFromImage(img v1.Image) ([]byte, error) {
 	return concatYamls, nil
 }
 
-func getYAMLsInArtifact(gzipStream io.Reader) ([][]byte, error) {
+func GetYAMLsInArtifact(gzipStream io.Reader) ([][]byte, error) {
 	uncompressedStream, err := gzip.NewReader(gzipStream)
 	if err != nil {
 		return nil, errors.Wrap(err, "gzip.NewReader() failed while decompressing tar gz")

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -14,26 +14,28 @@
 // limitations under the License.
 //
 
-package main
+package util
 
 import (
-	"os"
-
-	log "github.com/sirupsen/logrus"
+	"bytes"
+	"compress/gzip"
+	"io/ioutil"
 )
 
-func init() {
-	rootCmd.AddCommand(NewCmdSign())
-	rootCmd.AddCommand(NewCmdVerify())
-	rootCmd.AddCommand(NewCmdVerifyResource())
-	rootCmd.AddCommand(NewCmdApplyAfterVerify())
-
-	log.SetLevel(log.InfoLevel)
+func GzipCompress(in []byte) []byte {
+	var buffer bytes.Buffer
+	writer := gzip.NewWriter(&buffer)
+	_, _ = writer.Write(in)
+	writer.Close()
+	return buffer.Bytes()
 }
 
-func main() {
-	if err := rootCmd.Execute(); err != nil {
-		os.Exit(1)
+func GzipDecompress(in []byte) []byte {
+	reader := bytes.NewReader(in)
+	gzreader, _ := gzip.NewReader(reader)
+	out, err := ioutil.ReadAll(gzreader)
+	if err != nil {
+		return in
 	}
-	os.Exit(0)
+	return out
 }

--- a/pkg/util/yaml.go
+++ b/pkg/util/yaml.go
@@ -69,6 +69,19 @@ func FindYAMLsInDir(dirPath string) ([][]byte, error) {
 	return foundYAMLs, nil
 }
 
+func FindManifestYAML(concatYamlBytes, objBytes []byte) (bool, []byte) {
+	var obj *unstructured.Unstructured
+	err := yaml.Unmarshal(objBytes, &obj)
+	if err != nil {
+		return false, nil
+	}
+	apiVersion := obj.GetAPIVersion()
+	kind := obj.GetKind()
+	name := obj.GetName()
+	namespace := obj.GetNamespace()
+	return FindSingleYaml(concatYamlBytes, apiVersion, kind, name, namespace)
+}
+
 func FindSingleYaml(concatYamlBytes []byte, apiVersion, kind, name, namespace string) (bool, []byte) {
 	gv, err := schema.ParseGroupVersion(apiVersion)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Hirokuni-Kitahara1 hirokuni.kitahara1@ibm.com

This PR is to enable pattern based multi resource specification in `kubectl sigstore verify-resource` command.
Users will be able to specify multiple resources on cluster as exactly same as `kubectl get` command.


The corresponding issue: https://github.com/sigstore/k8s-manifest-sigstore/issues/5


<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
