### PR TITLE
enable to output `verify-resource` result in JSON/YAML format

### DIFF
--- a/cmd/kubectl-sigstore/verify_resource.go
+++ b/cmd/kubectl-sigstore/verify_resource.go
@@ -27,19 +27,29 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/ghodss/yaml"
 	"github.com/sigstore/k8s-manifest-sigstore/pkg/k8smanifest"
 	k8ssigutil "github.com/sigstore/k8s-manifest-sigstore/pkg/util"
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
 	metatable "k8s.io/apimachinery/pkg/api/meta/table"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
+
+const (
+	resultAPIVersion = "cosign.sigstore.dev/v1alpha1" // use this only for output result as json/yaml
+	resultKind       = "VerifyResourceResult"         // use this only for output result as json/yaml
+)
+
+var supportedOutputFormat = map[string]bool{"json": true, "yaml": true}
 
 func NewCmdVerifyResource() *cobra.Command {
 
 	var imageRef string
 	var keyPath string
 	var configPath string
+	var outputFormat string
 	cmd := &cobra.Command{
 		Use:   "verify-resource -f <YAMLFILE> [-i <IMAGE>]",
 		Short: "A command to verify Kubernetes manifests of resources on cluster",
@@ -47,7 +57,7 @@ func NewCmdVerifyResource() *cobra.Command {
 			fullArgs := getOriginalFullArgs("verify-resource")
 			_, kubeGetArgs := splitArgs(fullArgs)
 
-			err := verifyResource(kubeGetArgs, imageRef, keyPath, configPath)
+			err := verifyResource(kubeGetArgs, imageRef, keyPath, configPath, outputFormat)
 			if err != nil {
 				return err
 			}
@@ -59,11 +69,18 @@ func NewCmdVerifyResource() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&imageRef, "image", "i", "", "signed image name which bundles yaml files")
 	cmd.PersistentFlags().StringVarP(&keyPath, "key", "k", "", "path to your signing key (if empty, do key-less signing)")
 	cmd.PersistentFlags().StringVarP(&configPath, "config", "c", "", "path to verification config YAML file (for advanced verification)")
+	cmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "", "output format string, either \"json\" or \"yaml\" (if empty, a result is shown as a table)")
 
 	return cmd
 }
 
-func verifyResource(kubeGetArgs []string, imageRef, keyPath, configPath string) error {
+func verifyResource(kubeGetArgs []string, imageRef, keyPath, configPath, outputFormat string) error {
+	if outputFormat != "" {
+		if !supportedOutputFormat[outputFormat] {
+			return fmt.Errorf("`%s` is not supported output format", outputFormat)
+		}
+	}
+
 	kArgs := []string{"get", "--output", "json"}
 	kArgs = append(kArgs, kubeGetArgs...)
 	log.Debug("kube get args", strings.Join(kArgs, " "))
@@ -102,19 +119,32 @@ func verifyResource(kubeGetArgs []string, imageRef, keyPath, configPath string) 
 		vo.KeyPath = keyPath
 	}
 
-	results := []*k8smanifest.VerifyResourceResult{}
+	results := []SingleResult{}
 	for _, obj := range objs {
-		result, err := k8smanifest.VerifyResource(obj, vo)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err.Error())
-			return nil
+		log.Debug("checking kind: ", obj.GetKind(), ", name: ", obj.GetName())
+		vResult, err := k8smanifest.VerifyResource(obj, vo)
+		r := SingleResult{
+			Object: obj,
 		}
-		log.Debug("kind: ", obj.GetKind(), ", name: ", obj.GetName(), ", result: ", result)
-		results = append(results, result)
+		if err == nil {
+			r.Result = vResult
+		} else {
+			r.Error = err
+		}
+		log.Debug("result: ", r)
+		results = append(results, r)
 	}
 
-	resultTable := makeResourceResultTable(objs, results)
-	fmt.Println(string(resultTable))
+	var resultBytes []byte
+	if outputFormat == "" {
+		resultBytes = makeResourceResultTable(results)
+	} else if outputFormat == "json" {
+		resultBytes, _ = json.MarshalIndent(VerifyResourceResult(results), "", "    ") // pretty print json as well as kubectl get -o json
+	} else if outputFormat == "yaml" {
+		resultBytes, _ = yaml.Marshal(VerifyResourceResult(results))
+	}
+
+	fmt.Println(string(resultBytes))
 
 	return nil
 }
@@ -130,6 +160,8 @@ func splitArgs(args []string) ([]string, []string) {
 		"-k":       true,
 		"--config": true,
 		"-c":       true,
+		"--output": true,
+		"-o":       true,
 	}
 	skipIndex := map[int]bool{}
 	for i, s := range args {
@@ -150,30 +182,43 @@ func splitArgs(args []string) ([]string, []string) {
 }
 
 // generate result bytes in a table which will be shown in output
-func makeResourceResultTable(objs []unstructured.Unstructured, results []*k8smanifest.VerifyResourceResult) []byte {
-	tableResult := "NAME\tINSCOPE\tVERIFIED\tSIGNER\tERROR\tAGE\t\n"
-	for i, r := range results {
+func makeResourceResultTable(results []SingleResult) []byte {
+	tableResult := "NAME\tVALID\tSIGNER\tSIG_REF\tERROR\tAGE\t\n"
+	for _, r := range results {
+		// if it is out of scope (=skipped by config), skip to show it too
+		inscope := true
+		if r.Result != nil {
+			inscope = r.Result.InScope
+		}
+		if !inscope {
+			continue
+		}
+
 		// object
-		obj := objs[i]
+		obj := r.Object
 		resName := obj.GetName()
 		resTime := obj.GetCreationTimestamp()
 		resAge := getAge(resTime)
 		// verify result
-		verified := "false"
-		inscope := "true"
+		valid := "false"
+
 		signer := ""
-		if r != nil {
-			verified = strconv.FormatBool(r.Verified)
-			inscope = strconv.FormatBool(r.InScope)
-			signer = r.Signer
+		sigRef := ""
+		if r.Result != nil {
+			valid = strconv.FormatBool(r.Result.Verified)
+			signer = r.Result.Signer
+			sigRef = r.Result.SigRef
 		}
 		// failure reason
 		reason := ""
-		if r.Diff != nil && r.Diff.Size() > 0 {
-			reason = fmt.Sprintf("diff: %s", r.Diff)
+		if r.Error != nil {
+			reason = r.Error.Error()
+			reason = strings.Split(reason, ":")[0]
+		} else if r.Result.Diff != nil && r.Result.Diff.Size() > 0 {
+			reason = fmt.Sprintf("diff: %s", r.Result.Diff)
 		}
 		// make a row string
-		line := fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%s\t\n", resName, inscope, verified, signer, reason, resAge)
+		line := fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%s\t\n", resName, valid, signer, sigRef, reason, resAge)
 		tableResult = fmt.Sprintf("%s%s", tableResult, line)
 	}
 	writer := new(bytes.Buffer)
@@ -187,4 +232,97 @@ func makeResourceResultTable(objs []unstructured.Unstructured, results []*k8sman
 // convert the timestamp info to human readable string
 func getAge(t metav1.Time) string {
 	return metatable.ConvertToHumanReadableDateType(t)
+}
+
+type SingleResult struct {
+	Object unstructured.Unstructured         `json:"-"`
+	Result *k8smanifest.VerifyResourceResult `json:"result"`
+	Error  error                             `json:"-"`
+}
+
+type VerifyResourceResult []SingleResult
+
+// SingleResult contains a target object itself, but it is too much to show result.
+// So only corev1.ObjectReference will be shown in an output.
+func (r SingleResult) MarshalJSON() ([]byte, error) {
+	objRef := obj2ref(r.Object)
+	errStr := ""
+	if r.Error != nil {
+		errStr = r.Error.Error()
+	}
+	return json.Marshal(&struct {
+		Object corev1.ObjectReference            `json:"object"`
+		Result *k8smanifest.VerifyResourceResult `json:"result"`
+		Error  string                            `json:"error"`
+	}{
+		Object: objRef,
+		Result: r.Result,
+		Error:  errStr,
+	})
+}
+
+// SingleResult contains a target object itself, but it is too much to show result.
+// So only corev1.ObjectReference will be shown in an output.
+func (r SingleResult) MarshalYAML() ([]byte, error) {
+	objRef := obj2ref(r.Object)
+	errStr := ""
+	if r.Error != nil {
+		errStr = r.Error.Error()
+	}
+	return yaml.Marshal(&struct {
+		Object corev1.ObjectReference            `json:"object"`
+		Result *k8smanifest.VerifyResourceResult `json:"result"`
+		Error  string                            `json:"error"`
+	}{
+		Object: objRef,
+		Result: r.Result,
+		Error:  errStr,
+	})
+}
+
+// VerifyResourceResult is a wrapper for list of SingleResult,
+// and it will be output as a k8s resource for consistency with kubectl get xxxx -o json
+func (r VerifyResourceResult) MarshalJSON() ([]byte, error) {
+	results := []SingleResult{}
+	for _, sr := range r {
+		results = append(results, sr)
+	}
+	return json.Marshal(&struct {
+		APIVersion string         `json:"apiVersion"`
+		Kind       string         `json:"kind"`
+		Results    []SingleResult `json:"results"`
+	}{
+		APIVersion: resultAPIVersion,
+		Kind:       resultKind,
+		Results:    results,
+	})
+}
+
+// VerifyResourceResult is a wrapper for list of SingleResult,
+// and it will be output as a k8s resource for consistency with kubectl get xxxx -o yaml
+func (r VerifyResourceResult) MarshalYAML() ([]byte, error) {
+	results := []SingleResult{}
+	for _, sr := range r {
+		results = append(results, sr)
+	}
+	return yaml.Marshal(&struct {
+		APIVersion string         `json:"apiVersion"`
+		Kind       string         `json:"kind"`
+		Results    []SingleResult `json:"results"`
+	}{
+		APIVersion: resultAPIVersion,
+		Kind:       resultKind,
+		Results:    results,
+	})
+}
+
+func obj2ref(obj unstructured.Unstructured) corev1.ObjectReference {
+	return corev1.ObjectReference{
+		Kind:            obj.GetKind(),
+		Namespace:       obj.GetNamespace(),
+		Name:            obj.GetName(),
+		UID:             obj.GetUID(),
+		APIVersion:      obj.GetAPIVersion(),
+		ResourceVersion: obj.GetResourceVersion(),
+	}
 }

--- a/pkg/k8smanifest/sign.go
+++ b/pkg/k8smanifest/sign.go
@@ -39,7 +39,7 @@ const (
 	SignatureAnnotationKey   = "cosign.sigstore.dev/signature"
 	CertificateAnnotationKey = "cosign.sigstore.dev/certificate"
 	MessageAnnotationKey     = "cosign.sigstore.dev/message"
-	BundleAnnotationKey      = "cosign.sigstore.dev/bundle" // bundle is not supported in cosign.SignBlob() so far
+	BundleAnnotationKey      = "cosign.sigstore.dev/bundle" // bundle is not supported in cosign.SignBlob() yet
 )
 
 func Sign(inputDir string, so *SignOption) ([]byte, error) {

--- a/pkg/k8smanifest/verify_resource.go
+++ b/pkg/k8smanifest/verify_resource.go
@@ -60,6 +60,7 @@ type VerifyResourceResult struct {
 	Verified bool                `json:"verified"`
 	InScope  bool                `json:"inScope"`
 	Signer   string              `json:"signer"`
+	SigRef   string              `json:"sigRef"`
 	Diff     *mapnode.DiffResult `json:"diff"`
 }
 
@@ -75,6 +76,7 @@ func VerifyResource(obj unstructured.Unstructured, vo *VerifyResourceOption) (*V
 	verified := false
 	inScope := true // assume that input resource is in scope in verify-resource
 	signerName := ""
+	sigRef := ""
 	var err error
 
 	// if imageRef is not specified in args and it is found in object annotations, use the found image ref
@@ -84,6 +86,9 @@ func VerifyResource(obj unstructured.Unstructured, vo *VerifyResourceOption) (*V
 		if found {
 			vo.ImageRef = annoImageRef
 		}
+	}
+	if vo.ImageRef != "" {
+		sigRef = vo.ImageRef
 	}
 
 	// check if the resource should be skipped or not
@@ -132,6 +137,7 @@ func VerifyResource(obj unstructured.Unstructured, vo *VerifyResourceOption) (*V
 		Verified: verified,
 		InScope:  inScope,
 		Signer:   signerName,
+		SigRef:   sigRef,
 		Diff:     diff,
 	}, nil
 }

--- a/pkg/util/cache.go
+++ b/pkg/util/cache.go
@@ -1,0 +1,80 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package util
+
+import (
+	"fmt"
+	"time"
+)
+
+var _ Cache = &OnMemoryCache{}
+
+type Cache interface {
+	Set(key string, value ...interface{}) error
+	Get(key string) ([]interface{}, error)
+}
+
+type cachedObject struct {
+	timestamp time.Time
+	object    []interface{}
+}
+
+type OnMemoryCache struct {
+	TTL  time.Duration
+	data map[string]cachedObject
+}
+
+func (c *OnMemoryCache) Set(key string, value ...interface{}) error {
+	if c.data == nil {
+		c.data = map[string]cachedObject{}
+	}
+
+	c.data[key] = cachedObject{
+		timestamp: time.Now().UTC(),
+		object:    value,
+	}
+	return nil
+}
+
+func (c *OnMemoryCache) Get(key string) ([]interface{}, error) {
+	if c.data == nil {
+		c.data = map[string]cachedObject{}
+	}
+	c.clearExpiredData()
+
+	obj, ok := c.data[key]
+	if !ok {
+		return nil, fmt.Errorf("no cached data is found with key `%s`", key)
+	}
+	return obj.object, nil
+}
+
+func (c *OnMemoryCache) clearExpiredData() {
+	if c.data == nil {
+		c.data = map[string]cachedObject{}
+	}
+
+	newData := map[string]cachedObject{}
+	for key, obj := range c.data {
+		now := time.Now().UTC()
+		if now.Sub(obj.timestamp) > c.TTL {
+			continue
+		}
+		newData[key] = obj
+	}
+	c.data = newData
+}


### PR DESCRIPTION
Signed-off-by: Hirokuni-Kitahara1 hirokuni.kitahara1@ibm.com

this PR is for the issue: https://github.com/sigstore/k8s-manifest-sigstore/issues/8

- add `output` option to verify-resource command and enable to output verify-resource result in JSON/YAML format
- minimize the number of image pulls using on memory cache only in verify-resource



<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
