### PR TITLE
fix `sign` command to set oidc option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/r3labs/diff v1.1.0
 	github.com/sigstore/cosign v0.6.0
+	github.com/sigstore/fulcio v0.1.1
 	github.com/sigstore/sigstore v0.0.0-20210726180807-7e34e36ecda1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.2.1

--- a/pkg/cosign/sign.go
+++ b/pkg/cosign/sign.go
@@ -21,6 +21,12 @@ import (
 
 	cosigncli "github.com/sigstore/cosign/cmd/cosign/cli"
 	"github.com/sigstore/cosign/pkg/cosign"
+	fulcioclient "github.com/sigstore/fulcio/pkg/client"
+)
+
+const (
+	defaultOIDCIssuer   = "https://oauth2.sigstore.dev/auth"
+	defaultOIDCClientID = "sigstore"
 )
 
 func SignImage(imageRef string, keyPath, certPath *string, pf cosign.PassFunc, imageAnnotations map[string]interface{}) error {
@@ -31,11 +37,15 @@ func SignImage(imageRef string, keyPath, certPath *string, pf cosign.PassFunc, i
 	idToken := ""
 
 	rekorSeverURL := getRekorServerURL()
+	fulcioServerURL := fulcioclient.SigstorePublicServerURL
 
 	opt := cosigncli.KeyOpts{
-		Sk:       sk,
-		IDToken:  idToken,
-		RekorURL: rekorSeverURL,
+		Sk:           sk,
+		IDToken:      idToken,
+		RekorURL:     rekorSeverURL,
+		FulcioURL:    fulcioServerURL,
+		OIDCIssuer:   defaultOIDCIssuer,
+		OIDCClientID: defaultOIDCClientID,
 	}
 	if pf != nil {
 		opt.PassFunc = pf


### PR DESCRIPTION
Signed-off-by: Hirokuni-Kitahara1 <hirokuni.kitahara1@ibm.com>

- add oidc options as default value to support cosign v1.0.1 keyless signing

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
