### PR TITLE
add an option to configure a namespace for dryrun in `verify-resource`

### DIFF
--- a/pkg/k8smanifest/option.go
+++ b/pkg/k8smanifest/option.go
@@ -42,7 +42,8 @@ type VerifyResourceOption struct {
 	verifyOption `json:""`
 	SkipObjects  ObjectReferenceList `json:"skipObjects,omitempty"`
 
-	CheckDryRunForApply bool `json:"-"`
+	CheckDryRunForApply bool   `json:"-"`
+	DryRunNamespace     string `json:"-"`
 }
 
 // option for VerifyManifest()


### PR DESCRIPTION
Signed-off-by: Hirokuni-Kitahara1 <hirokuni.kitahara1@ibm.com>

add an option `DryRunNamespace` to `VerifyResourceOption` , and this option decides which namespace is used for dryrun inside `verify-resource` instead of `default` namespace .

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
