### PR TITLE
fix manifest detection config bug

### DIFF
--- a/pkg/k8smanifest/verify.go
+++ b/pkg/k8smanifest/verify.go
@@ -382,7 +382,12 @@ func (f *AnnotationManifestFetcher) Fetch(objYAMLBytes []byte) ([][]byte, string
 
 	concatYAMLbytes := k8smnfutil.ConcatenateYAMLs(yamls)
 
-	found, resourceManifests := k8smnfutil.FindManifestYAML(concatYAMLbytes, objYAMLBytes, &f.maxResourceManifestNum, f.ignoreFields)
+	var maxResourceManifestNumPtr *int
+	if f.maxResourceManifestNum > 0 {
+		maxResourceManifestNumPtr = &f.maxResourceManifestNum
+	}
+
+	found, resourceManifests := k8smnfutil.FindManifestYAML(concatYAMLbytes, objYAMLBytes, maxResourceManifestNumPtr, f.ignoreFields)
 	if !found {
 		return nil, "", errors.New("failed to find a YAML manifest in the gzipped message")
 	}


### PR DESCRIPTION
Signed-off-by: Hirokuni-Kitahara1 <hirokuni.kitahara1@ibm.com>

fix a bug around verification configuration for annotation-embedded signature

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
