### PR TITLE
fix input path issue in sign command

### DIFF
--- a/cmd/kubectl-sigstore/sign.go
+++ b/cmd/kubectl-sigstore/sign.go
@@ -18,12 +18,16 @@ package main
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/sigstore/k8s-manifest-sigstore/pkg/k8smanifest"
+	k8smnfutil "github.com/sigstore/k8s-manifest-sigstore/pkg/util"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
+
+const filenameIfInputIsDir = "manifest.yaml"
 
 func NewCmdSign() *cobra.Command {
 
@@ -59,7 +63,14 @@ func NewCmdSign() *cobra.Command {
 
 func sign(inputDir, imageRef, keyPath, output string, updateAnnotation bool, annotations []string) error {
 	if output == "" && updateAnnotation {
-		output = inputDir + ".signed"
+		if isDir, _ := k8smnfutil.IsDir(inputDir); isDir {
+			// e.g.) "./yamls/" --> "./yamls/manifest.yaml.signed"
+			output = filepath.Join(inputDir, filenameIfInputIsDir+".signed")
+		} else {
+			// e.g.) "configmap.yaml" --> "configmap.yaml.signed"
+			output = inputDir + ".signed"
+		}
+
 	}
 
 	anntns, err := parseAnnotations(annotations)

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 // AnnotationWriter represents the embedAnnotation function
@@ -52,16 +53,23 @@ func TarGzCompress(src string, buf io.Writer, mo *MutateOptions) error {
 		return errors.Wrap(err, "error occurred during creating temp dir for tar gz compression")
 	}
 	defer os.RemoveAll(dir)
+	log.Debugf("use temp dir %s for signing working directory", dir)
 
 	// create tmpSrc dir and copy src files into this
 	// in order to avoid relative path error on decompression like `tar xzf: Path contains '..'`
 	basename := filepath.Base(src)
+	// filepath.Base() returns ".." for an input like "../"
+	// replace it with empty string to avoid the case of filepath.Join(tmpDir, "..") which could cause some permission errors
+	if basename == ".." {
+		basename = ""
+	}
 	tmpSrc := filepath.Join(dir, basename)
 	err = copyDir(src, tmpSrc)
 	if err != nil {
 		return errors.Wrap(err, "error occurred during copying src dir for tar gz compression")
 	}
 	tarGzSrc := tmpSrc
+	log.Debugf("finished to copy from %s to %s", src, tmpSrc)
 
 	// if mutation option is specified, should mutate files before tar gz compression
 	// in order to avoid file header inconsistency
@@ -142,7 +150,6 @@ func TarGzCompress(src string, buf io.Writer, mo *MutateOptions) error {
 	if errV = zr.Close(); errV != nil {
 		return errV
 	}
-	//
 	return nil
 }
 
@@ -269,4 +276,12 @@ func copyFile(src string, dst string) error {
 		return err
 	}
 	return nil
+}
+
+func IsDir(path string) (bool, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return false, err
+	}
+	return fi.IsDir(), nil
 }


### PR DESCRIPTION
Signed-off-by: Hirokuni-Kitahara1 hirokuni.kitahara1@ibm.com

- fix issue of relative path input like "../xxxx" for sign command
- fix issue of output file path like "./xxxx/.signed" against directory path input for sign command

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
