### PR TITLE
enable to load config from constraint resource in a cluster

### DIFF
--- a/cmd/kubectl-sigstore/verify_resource.go
+++ b/cmd/kubectl-sigstore/verify_resource.go
@@ -53,6 +53,11 @@ const (
 )
 
 const (
+	defaultConfigKindForConfigMap  = "ConfigMap"
+	defaultConfigKindForConstraint = "ManifestIntegrityConstraint"
+)
+
+const (
 	defaultConfigFieldPathConstraint = "spec.parameters"
 	defaultConfigFieldPathConfigMap  = "data.\"config.yaml\""
 )
@@ -586,6 +591,13 @@ func getConfigPathFromConfigFlags(path, ctype, kind, name, namespace, field stri
 
 	if ctype == configTypeFile {
 		return path, field
+	}
+	if kind == "" {
+		if ctype == configTypeConstraint {
+			kind = defaultConfigKindForConstraint
+		} else if ctype == configTypeConfigMap {
+			kind = defaultConfigKindForConfigMap
+		}
 	}
 	newPath := ""
 	if namespace == "" {

--- a/pkg/k8smanifest/option.go
+++ b/pkg/k8smanifest/option.go
@@ -17,6 +17,7 @@
 package k8smanifest
 
 import (
+	"fmt"
 	"os"
 	"strings"
 

--- a/pkg/util/gzip.go
+++ b/pkg/util/gzip.go
@@ -32,7 +32,10 @@ func GzipCompress(in []byte) []byte {
 
 func GzipDecompress(in []byte) []byte {
 	reader := bytes.NewReader(in)
-	gzreader, _ := gzip.NewReader(reader)
+	gzreader, err := gzip.NewReader(reader)
+	if err != nil {
+		return in
+	}
 	out, err := ioutil.ReadAll(gzreader)
 	if err != nil {
 		return in


### PR DESCRIPTION
Signed-off-by: Hirokuni-Kitahara1 hirokuni.kitahara1@ibm.com

enable the command like this as equivalent to a local config file

```
# load config from a resource in a cluster
$ kubectl sigstore verify-resource cm -n sample-ns sample-cm --config-type constraint --config-name sample-constraint

# equivalent command
$ kubectl sigstore verify-resource cm -n sample-ns sample-cm --config config.yaml
```

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
