### PR TITLE
add `manifest-build` command for YAML manifest provenance

### DIFF
--- a/cmd/kubectl-sigstore/main.go
+++ b/cmd/kubectl-sigstore/main.go
@@ -49,6 +49,7 @@ func init() {
 	rootCmd.AddCommand(NewCmdVerify())
 	rootCmd.AddCommand(NewCmdVerifyResource())
 	rootCmd.AddCommand(NewCmdApplyAfterVerify())
+	rootCmd.AddCommand(NewCmdManifestBuild())
 
 	kubectlOptions.ConfigFlags.AddFlags(rootCmd.PersistentFlags())
 

--- a/cmd/kubectl-sigstore/manifest_build.go
+++ b/cmd/kubectl-sigstore/manifest_build.go
@@ -1,11 +1,11 @@
 //
-// Copyright 2020 IBM Corporation
+// Copyright 2021 The Sigstore Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/kubectl-sigstore/manifest_build.go
+++ b/cmd/kubectl-sigstore/manifest_build.go
@@ -1,0 +1,118 @@
+//
+// Copyright 2020 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"time"
+
+	"github.com/pkg/errors"
+	kustbuildutil "github.com/sigstore/k8s-manifest-sigstore/pkg/util/manifestbuild/kustomize"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdManifestBuild() *cobra.Command {
+
+	var baseDir string
+	var imageRef string
+	var keyPath string
+	var outputPath string
+	var provenancePath string
+	var kustomizeMode bool
+	var signProvenance bool
+	cmd := &cobra.Command{
+		Use:   "manifest-build --kustomize -d BASE_DIR -o MANIFEST_OUTPUT --provenance PROVENANCE_OUTPUT",
+		Short: "A command to build a Kubernetes YAML manifest with provenance",
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			err := buildManifest(baseDir, outputPath, provenancePath, imageRef, keyPath, kustomizeMode, signProvenance)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	cmd.PersistentFlags().BoolVar(&kustomizeMode, "kustomize", false, "enable kustomize mode")
+	cmd.PersistentFlags().BoolVar(&signProvenance, "sign", false, "whether to sign a generated provenance for uploading it to rekor")
+	cmd.PersistentFlags().StringVarP(&baseDir, "dir", "d", "", "kustomize base dir")
+	cmd.PersistentFlags().StringVarP(&outputPath, "output", "o", "", "path to output manifest file")
+	cmd.PersistentFlags().StringVarP(&provenancePath, "provenance", "p", "", "path to output provenance file")
+	cmd.PersistentFlags().StringVarP(&imageRef, "image", "i", "", "image reference in which a generated manifest is stored")
+	cmd.PersistentFlags().StringVarP(&keyPath, "key", "k", "", "path to your signing key")
+	return cmd
+}
+
+func buildManifest(baseDir, outputPath, provenancePath, imageRef, keyPath string, kustomizeMode, signProvenance bool) error {
+	startTime := time.Now().UTC()
+	wd, err := os.Getwd()
+	if err != nil {
+		return errors.Wrap(err, "failed to get current working directory")
+	}
+	// baseDir = filepath.Clean(filepath.Join(wd, baseDir))
+	// TODO: support additinoal args for kustomize command
+	manifest, err := kustbuildutil.KustomizeExec(wd, "build", baseDir)
+	if err != nil {
+		return errors.Wrap(err, "failed to execute kustomize build")
+	}
+	manifestFile := outputPath
+	err = ioutil.WriteFile(manifestFile, []byte(manifest), 0644)
+	if err != nil {
+		return errors.Wrap(err, "failed to create a manifest file")
+	}
+	digest, err := kustbuildutil.GetDigestOfArtifact(manifestFile)
+	if err != nil {
+		return errors.Wrap(err, "failed to get a digest of a generated manifest file")
+	}
+
+	finishTime := time.Now().UTC()
+	recipeCmds := []string{"kubectl", "sigstore"}
+	recipeCmds = append(recipeCmds, os.Args[1:]...)
+	prov, err := kustbuildutil.GenerateProvenance(provenancePath, digest, baseDir, startTime, finishTime, recipeCmds)
+	if err != nil {
+		return errors.Wrap(err, "failed to generate a provenance")
+	}
+	provBytes, err := json.Marshal(prov)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal provenance")
+	}
+	tmpProvFile := "./provenance.json"
+	err = ioutil.WriteFile(tmpProvFile, provBytes, 0644)
+	if err != nil {
+		return errors.Wrap(err, "failed to create a provenance file")
+	}
+
+	if signProvenance && keyPath != "" {
+		attestation, err := kustbuildutil.GenerateAttestation(tmpProvFile, keyPath)
+		if err != nil {
+			return errors.Wrap(err, "failed to generate an attestation data")
+		}
+		attestationBytes, err := json.Marshal(attestation)
+		if err != nil {
+			return errors.Wrap(err, "failed to marshal an attestation data")
+		}
+		tmpAttestationFile := "./attestation.json"
+		err = ioutil.WriteFile(tmpAttestationFile, attestationBytes, 0644)
+		if err != nil {
+			return errors.Wrap(err, "failed to create an attestation file")
+		}
+	}
+
+	return nil
+}

--- a/cmd/kubectl-sigstore/manifest_build.go
+++ b/cmd/kubectl-sigstore/manifest_build.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -27,6 +28,10 @@ import (
 	kustbuildutil "github.com/sigstore/k8s-manifest-sigstore/pkg/util/manifestbuild/kustomize"
 	"github.com/spf13/cobra"
 )
+
+var supportedMode = []string{
+	"--kustomize",
+}
 
 func NewCmdManifestBuild() *cobra.Command {
 
@@ -61,6 +66,11 @@ func NewCmdManifestBuild() *cobra.Command {
 }
 
 func buildManifest(baseDir, outputPath, provenancePath, imageRef, keyPath string, kustomizeMode, signProvenance bool) error {
+
+	if !kustomizeMode {
+		return fmt.Errorf("only the following manifest types are supported: %v", supportedMode)
+	}
+
 	startTime := time.Now().UTC()
 	wd, err := os.Getwd()
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.2.1
 	github.com/tektoncd/chains v0.3.0
+	github.com/theupdateframework/go-tuf v0.0.0-20210722233521-90e262754396
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.21.3
@@ -30,6 +31,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7
 	k8s.io/kubectl v0.19.4
 	sigs.k8s.io/controller-runtime v0.8.3
+	sigs.k8s.io/kustomize/api v0.8.8
 )
 
 replace (

--- a/pkg/util/manifestbuild/kustomize/kustomize.go
+++ b/pkg/util/manifestbuild/kustomize/kustomize.go
@@ -1,0 +1,388 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package kustomize
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	"github.com/pkg/errors"
+	"sigs.k8s.io/kustomize/api/filesys"
+	"sigs.k8s.io/kustomize/api/types"
+)
+
+const kustomizationFileName = "kustomization.yaml"
+const gitCmd = "git"
+const kustCmd = "kustomize"
+
+type KustomizationResource struct {
+	GitRepo *GitRepoResult
+	File    *FileInfo
+}
+
+func LoadKustomization(fpath, baseDir string, inRemoteRepo bool) ([]*KustomizationResource, error) {
+	isDir, err := IsDir(fpath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to judge if %s is directory or not", fpath)
+	}
+	if isDir {
+		baseDir = fpath
+		fpath = filepath.Join(fpath, kustomizationFileName)
+	}
+	if !FileExists(fpath) {
+		return nil, fmt.Errorf("%s does not exists", fpath)
+	}
+	data, err := ioutil.ReadFile(fpath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read %s", fpath)
+	}
+	var k *types.Kustomization
+	err = yaml.Unmarshal(data, &k)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to unmarshal a content of %s into %T", fpath, k)
+	}
+	k.FixKustomizationPostUnmarshalling()
+
+	// these resoruces are used as "provenance materials" later
+	// files in a local filesystem --> File resource
+	// all resources in a remote git repository --> GitRepo resource
+	resources := []*KustomizationResource{}
+	if !inRemoteRepo {
+		kustFileHash, err := Sha256Hash(fpath)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get sha256 hash of %s", fpath)
+		}
+		kustRes := &KustomizationResource{File: &FileInfo{Name: fpath, Hash: kustFileHash}}
+		resources = append(resources, kustRes)
+	}
+	for _, res := range k.Resources {
+		if IsRepositoryResource(res) {
+			repo, err := prepareBaseDirForRemoteRepository(res)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to create a directory for a git repository resource %s", res)
+			}
+			kustPath := filepath.Join(repo.RootDir, repo.Path, kustomizationFileName)
+			repoBaseDir := filepath.Join(repo.RootDir, repo.Path)
+			rr := &KustomizationResource{GitRepo: repo}
+			resources = append(resources, rr)
+			remoteResources, err := LoadKustomization(kustPath, repoBaseDir, true)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to load resources in a git repository %s", res)
+			}
+			resources = append(resources, remoteResources...)
+		} else {
+			rPath := filepath.Clean(filepath.Join(baseDir, res))
+			rIsFile, err := IsFile(rPath)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to judge if %s is a file or not", res)
+			}
+			if rIsFile {
+				if inRemoteRepo {
+					// ignore local file resources inside remote repository
+					// because they can be identified only with repo information
+					continue
+				}
+				// files in a local filesystem should be included in resources as File resource
+				rHash, err := Sha256Hash(rPath)
+				if err != nil {
+					return nil, errors.Wrapf(err, "failed to　get sha256 hash of %s", rPath)
+				}
+				fr := &KustomizationResource{File: &FileInfo{Name: rPath, Hash: rHash}}
+				resources = append(resources, fr)
+			} else {
+				// otherwise, this resource points a directory that contains a sub kustomization.yaml
+				// so load it and add resources
+				kustFile := filepath.Clean(filepath.Join(rPath, kustomizationFileName))
+
+				if !inRemoteRepo {
+					// if this is not in a remote repository, the kustomization.yaml will be added to File resources
+					kustHash, err := Sha256Hash(kustFile)
+					if err != nil {
+						return nil, errors.Wrapf(err, "failed to　get sha256 hash of %s", kustFile)
+					}
+					fr := &KustomizationResource{File: &FileInfo{Name: kustFile, Hash: kustHash}}
+					resources = append(resources, fr)
+				}
+				// load a sub kustomization.yaml
+				kustFileDir := filepath.Dir(kustFile)
+				subResources, err := LoadKustomization(kustFile, kustFileDir, inRemoteRepo)
+				if err != nil {
+					return nil, errors.Wrapf(err, "failed to load a kustomization file %s", kustFile)
+				}
+				resources = append(resources, subResources...)
+			}
+		}
+	}
+
+	return resources, nil
+}
+
+func Sha256Hash(fpath string) (string, error) {
+	f, err := os.Open(fpath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	hash := fmt.Sprintf("%x", h.Sum(nil))
+	return hash, nil
+}
+
+type GitRepoResult struct {
+	RootDir  string
+	URL      string
+	Revision string
+	CommitID string
+	Path     string
+}
+
+type FileInfo struct {
+	Name string
+	Hash string
+}
+
+func prepareBaseDirForRemoteRepository(url string) (*GitRepoResult, error) {
+	r := &GitRepoResult{}
+	r.URL, r.Revision, r.Path = parseGitURLinKustomization(url)
+	cDir, err := filesys.NewTmpConfirmedDir()
+	if err != nil {
+		return nil, err
+	}
+	r.RootDir = cDir.String()
+
+	_, err = CmdExec(gitCmd, r.RootDir, "init")
+	if err != nil {
+		return nil, err
+	}
+	_, err = CmdExec(gitCmd, r.RootDir, "remote", "add", "origin", r.URL)
+	if err != nil {
+		return nil, err
+	}
+	rev := "HEAD"
+	if r.Revision != "" {
+		rev = r.Revision
+	}
+	_, err = CmdExec(gitCmd, r.RootDir, "fetch", "--depth=1", "origin", rev)
+	if err != nil {
+		return nil, err
+	}
+	_, err = CmdExec(gitCmd, r.RootDir, "checkout", "FETCH_HEAD")
+	if err != nil {
+		return nil, err
+	}
+	commitGetOut, err := CmdExec(gitCmd, r.RootDir, "rev-parse", "FETCH_HEAD")
+	if err != nil {
+		return nil, err
+	}
+	r.CommitID = strings.TrimSuffix(commitGetOut, "\n")
+
+	_, err = CmdExec(gitCmd, r.RootDir, "submodule", "update", "--init", "--recursive")
+	if err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+func parseGitURLinKustomization(urlInKustomization string) (string, string, string) {
+	host, orgRepo, path, gitRef, gitSuff := parseGitUrl(urlInKustomization)
+	return host + orgRepo + gitSuff, gitRef, path
+}
+
+func CmdExec(baseCmd, dir string, args ...string) (string, error) {
+	cmd := exec.Command(baseCmd, args...)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	err := cmd.Run()
+	if err != nil {
+		return "", errors.Wrap(err, stderr.String())
+	}
+	out := stdout.String()
+	return out, nil
+}
+
+func KustomizeExec(dir string, args ...string) (string, error) {
+	return CmdExec(kustCmd, dir, args...)
+}
+
+func IsRepositoryResource(path string) bool {
+	host, orgRepo, _, _, _ := parseGitUrl(path)
+	if host != "" && orgRepo != "" {
+		return true
+	}
+	return false
+}
+
+func IsFileResource(path string) bool {
+	return !IsRepositoryResource(path)
+}
+
+func IsFile(name string) (bool, error) {
+	isDir, err := IsDir(name)
+	if err != nil {
+		return false, err
+	}
+	return !isDir, nil
+}
+
+func IsDir(name string) (bool, error) {
+	fInfo, err := os.Stat(name)
+	if err != nil {
+		return false, err
+	}
+	return fInfo.IsDir(), nil
+}
+
+func FileExists(fpath string) bool {
+	if _, err := os.Stat(fpath); err == nil {
+		return true
+	}
+	return false
+}
+
+const (
+	refQuery      = "?ref="
+	refQueryRegex = "\\?(version|ref)="
+	gitSuffix     = ".git"
+	gitDelimiter  = "_git/"
+)
+
+// From strings like git@github.com:someOrg/someRepo.git or
+// https://github.com/someOrg/someRepo?ref=someHash, extract
+// the parts.
+func parseGitUrl(n string) (
+	host string, orgRepo string, path string, gitRef string, gitSuff string) {
+
+	if strings.Contains(n, gitDelimiter) {
+		index := strings.Index(n, gitDelimiter)
+		// Adding _git/ to host
+		host = normalizeGitHostSpec(n[:index+len(gitDelimiter)])
+		orgRepo = strings.Split(strings.Split(n[index+len(gitDelimiter):], "/")[0], "?")[0]
+		path, gitRef = peelQuery(n[index+len(gitDelimiter)+len(orgRepo):])
+		return
+	}
+	host, n = parseHostSpec(n)
+	gitSuff = gitSuffix
+	if strings.Contains(n, gitSuffix) {
+		index := strings.Index(n, gitSuffix)
+		orgRepo = n[0:index]
+		n = n[index+len(gitSuffix):]
+		path, gitRef = peelQuery(n)
+		return
+	}
+
+	i := strings.Index(n, "/")
+	if i < 1 {
+		return "", "", "", "", ""
+	}
+	j := strings.Index(n[i+1:], "/")
+	if j >= 0 {
+		j += i + 1
+		orgRepo = n[:j]
+		path, gitRef = peelQuery(n[j+1:])
+		return
+	}
+	path = ""
+	orgRepo, gitRef = peelQuery(n)
+	return host, orgRepo, path, gitRef, gitSuff
+}
+
+func peelQuery(arg string) (string, string) {
+
+	r, _ := regexp.Compile(refQueryRegex)
+	j := r.FindStringIndex(arg)
+
+	if len(j) > 0 {
+		return arg[:j[0]], arg[j[0]+len(r.FindString(arg)):]
+	}
+	return arg, ""
+}
+
+func parseHostSpec(n string) (string, string) {
+	var host string
+	// Start accumulating the host part.
+	for _, p := range []string{
+		// Order matters here.
+		"git::", "gh:", "ssh://", "https://", "http://",
+		"git@", "github.com:", "github.com/"} {
+		if len(p) < len(n) && strings.ToLower(n[:len(p)]) == p {
+			n = n[len(p):]
+			host += p
+		}
+	}
+	if host == "git@" {
+		i := strings.Index(n, "/")
+		if i > -1 {
+			host += n[:i+1]
+			n = n[i+1:]
+		} else {
+			i = strings.Index(n, ":")
+			if i > -1 {
+				host += n[:i+1]
+				n = n[i+1:]
+			}
+		}
+		return host, n
+	}
+
+	// If host is a http(s) or ssh URL, grab the domain part.
+	for _, p := range []string{
+		"ssh://", "https://", "http://"} {
+		if strings.HasSuffix(host, p) {
+			i := strings.Index(n, "/")
+			if i > -1 {
+				host = host + n[0:i+1]
+				n = n[i+1:]
+			}
+			break
+		}
+	}
+
+	return normalizeGitHostSpec(host), n
+}
+
+func normalizeGitHostSpec(host string) string {
+	s := strings.ToLower(host)
+	if strings.Contains(s, "github.com") {
+		if strings.Contains(s, "git@") || strings.Contains(s, "ssh:") {
+			host = "git@github.com:"
+		} else {
+			host = "https://github.com/"
+		}
+	}
+	if strings.HasPrefix(s, "git::") {
+		host = strings.TrimPrefix(s, "git::")
+	}
+	return host
+}

--- a/pkg/util/manifestbuild/kustomize/kustomize.go
+++ b/pkg/util/manifestbuild/kustomize/kustomize.go
@@ -43,6 +43,8 @@ type KustomizationResource struct {
 	File    *FileInfo
 }
 
+// it loads a kustomization.yaml in a specified base dir and its resources and bases even in remote repository.
+// then it returns a list of resources that have file hash info for files and commit digest info for remote repos.
 func LoadKustomization(fpath, baseDir string, inRemoteRepo bool) ([]*KustomizationResource, error) {
 	isDir, err := IsDir(fpath)
 	if err != nil {
@@ -140,6 +142,7 @@ func LoadKustomization(fpath, baseDir string, inRemoteRepo bool) ([]*Kustomizati
 	return resources, nil
 }
 
+// get a sha 256 hash for a file
 func Sha256Hash(fpath string) (string, error) {
 	f, err := os.Open(fpath)
 	if err != nil {
@@ -215,6 +218,7 @@ func parseGitURLinKustomization(urlInKustomization string) (string, string, stri
 	return host + orgRepo + gitSuff, gitRef, path
 }
 
+// execute command in a specified dir
 func CmdExec(baseCmd, dir string, args ...string) (string, error) {
 	cmd := exec.Command(baseCmd, args...)
 	var stdout bytes.Buffer
@@ -232,10 +236,12 @@ func CmdExec(baseCmd, dir string, args ...string) (string, error) {
 	return out, nil
 }
 
+// execute kustomize command
 func KustomizeExec(dir string, args ...string) (string, error) {
 	return CmdExec(kustCmd, dir, args...)
 }
 
+// returns if a resource in kustomization.yaml is a git repo or not
 func IsRepositoryResource(path string) bool {
 	host, orgRepo, _, _, _ := parseGitUrl(path)
 	if host != "" && orgRepo != "" {
@@ -244,10 +250,12 @@ func IsRepositoryResource(path string) bool {
 	return false
 }
 
+// returns if a resource in kustomization.yaml is a local file/dir or not
 func IsFileResource(path string) bool {
 	return !IsRepositoryResource(path)
 }
 
+// returns if a filepath is pointing a file or not
 func IsFile(name string) (bool, error) {
 	isDir, err := IsDir(name)
 	if err != nil {
@@ -256,6 +264,7 @@ func IsFile(name string) (bool, error) {
 	return !isDir, nil
 }
 
+// returns if a filepath is pointing a directory or not
 func IsDir(name string) (bool, error) {
 	fInfo, err := os.Stat(name)
 	if err != nil {
@@ -264,6 +273,7 @@ func IsDir(name string) (bool, error) {
 	return fInfo.IsDir(), nil
 }
 
+// returns if a filepath exists or not
 func FileExists(fpath string) bool {
 	if _, err := os.Stat(fpath); err == nil {
 		return true

--- a/pkg/util/manifestbuild/kustomize/provenance.go
+++ b/pkg/util/manifestbuild/kustomize/provenance.go
@@ -1,0 +1,253 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package kustomize
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	intoto "github.com/in-toto/in-toto-golang/in_toto"
+	"github.com/in-toto/in-toto-golang/pkg/ssl"
+	"github.com/theupdateframework/go-tuf/encrypted"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+const cosignPwdEnvKey = "COSIGN_PASSWORD"
+
+func GenerateProvenance(artifactName, digest, kustomizeBase string, startTime, finishTime time.Time, recipeCmd []string) (*intoto.Statement, error) {
+
+	subjects := []intoto.Subject{}
+	subjects = append(subjects, intoto.Subject{
+		Name: artifactName,
+		Digest: intoto.DigestSet{
+			"sha256": digest,
+		},
+	})
+
+	materials, err := generateMaterialsFromKustomization(kustomizeBase)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: set recipe command dynamically or somthing
+	entryPoint := recipeCmd[0]
+	recipe := intoto.ProvenanceRecipe{
+		EntryPoint: entryPoint,
+		Arguments:  recipeCmd[1:],
+	}
+	it := &intoto.Statement{
+		StatementHeader: intoto.StatementHeader{
+			Type:          intoto.StatementInTotoV01,
+			PredicateType: intoto.PredicateProvenanceV01,
+			Subject:       subjects,
+		},
+		Predicate: intoto.ProvenancePredicate{
+			Metadata: intoto.ProvenanceMetadata{
+				Reproducible:    true,
+				BuildStartedOn:  &startTime,
+				BuildFinishedOn: &finishTime,
+			},
+
+			Materials: materials,
+			Recipe:    recipe,
+		},
+	}
+	return it, nil
+}
+
+func GenerateAttestation(provPath, privKeyPath string) (*ssl.Envelope, error) {
+	b, err := ioutil.ReadFile(provPath)
+	if err != nil {
+		return nil, err
+	}
+	ecdsaPriv, _ := ioutil.ReadFile(filepath.Clean(privKeyPath))
+	pb, _ := pem.Decode(ecdsaPriv)
+	pwd := os.Getenv(cosignPwdEnvKey) //GetPass(true)
+	x509Encoded, err := encrypted.Decrypt(pb.Bytes, []byte(pwd))
+	if err != nil {
+		return nil, err
+	}
+	priv, err := x509.ParsePKCS8PrivateKey(x509Encoded)
+	if err != nil {
+		return nil, err
+	}
+
+	signer, err := ssl.NewEnvelopeSigner(&IntotoSigner{
+		priv: priv.(*ecdsa.PrivateKey),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	envelope, err := signer.SignPayload("application/vnd.in-toto+json", b)
+	if err != nil {
+		return nil, err
+	}
+
+	// Now verify
+	err = signer.Verify(envelope)
+	if err != nil {
+		return nil, err
+	}
+	return envelope, nil
+}
+
+func GetDigestOfArtifact(artifactPath string) (string, error) {
+	var digest string
+	var err error
+	if FileExists(artifactPath) {
+		// if file exists, then use hash of the file
+		digest, err = Sha256Hash(artifactPath)
+	} else {
+		// otherwise, artifactPath should be an image ref
+		digest, err = GetImageDigest(artifactPath)
+	}
+	return digest, err
+}
+
+func OverwriteArtifactInProvenance(provPath, overwriteArtifact string) (string, error) {
+	b, err := ioutil.ReadFile(provPath)
+	if err != nil {
+		return "", err
+	}
+	var prov *intoto.Statement
+	err = json.Unmarshal(b, &prov)
+	if err != nil {
+		return "", err
+	}
+	digest, err := GetDigestOfArtifact(overwriteArtifact)
+	if err != nil {
+		return "", err
+	}
+	subj := intoto.Subject{
+		Name: overwriteArtifact,
+		Digest: intoto.DigestSet{
+			"sha256": digest,
+		},
+	}
+	if len(prov.Subject) == 0 {
+		prov.Subject = append(prov.Subject, subj)
+	} else {
+		prov.Subject[0] = subj
+	}
+	provBytes, _ := json.Marshal(prov)
+	dir, err := ioutil.TempDir("", "newprov")
+	if err != nil {
+		return "", err
+	}
+	basename := filepath.Base(provPath)
+	newProvPath := filepath.Join(dir, basename)
+	err = ioutil.WriteFile(newProvPath, provBytes, 0644)
+	if err != nil {
+		return "", err
+	}
+	return newProvPath, nil
+}
+
+func generateMaterialsFromKustomization(kustomizeBase string) ([]intoto.ProvenanceMaterial, error) {
+	materials := []intoto.ProvenanceMaterial{}
+	resources, err := LoadKustomization(kustomizeBase, "", false)
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range resources {
+		m := resourceToMaterial(r)
+		if m == nil {
+			continue
+		}
+		materials = append(materials, *m)
+	}
+	return materials, nil
+}
+
+func resourceToMaterial(kr *KustomizationResource) *intoto.ProvenanceMaterial {
+	if kr.File == nil && kr.GitRepo == nil {
+		return nil
+	} else if kr.File != nil {
+		m := &intoto.ProvenanceMaterial{
+			URI: kr.File.Name,
+			Digest: intoto.DigestSet{
+				"hash": kr.File.Hash,
+			},
+		}
+		return m
+	} else if kr.GitRepo != nil {
+		m := &intoto.ProvenanceMaterial{
+			URI: kr.GitRepo.URL,
+			Digest: intoto.DigestSet{
+				"commit":   kr.GitRepo.CommitID,
+				"revision": kr.GitRepo.Revision,
+				"path":     kr.GitRepo.Path,
+			},
+		}
+		return m
+	}
+	return nil
+}
+
+func GetImageDigest(imageRef string) (string, error) {
+	ref, err := name.ParseReference(imageRef)
+	if err != nil {
+		return "", err
+	}
+	img, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err != nil {
+		return "", err
+	}
+	hash, err := img.Digest()
+	if err != nil {
+		return "", err
+	}
+	hashValue := strings.TrimPrefix(hash.String(), "sha256:")
+	return hashValue, nil
+}
+
+type IntotoSigner struct {
+	priv *ecdsa.PrivateKey
+}
+
+func (it *IntotoSigner) Sign(data []byte) ([]byte, string, error) {
+	h := sha256.Sum256(data)
+	sig, err := it.priv.Sign(rand.Reader, h[:], crypto.SHA256)
+	if err != nil {
+		return nil, "", err
+	}
+	return sig, "", nil
+}
+
+func (it *IntotoSigner) Verify(_ string, data, sig []byte) error {
+	h := sha256.Sum256(data)
+	ok := ecdsa.VerifyASN1(&it.priv.PublicKey, h[:], sig)
+	if ok {
+		return nil
+	}
+	return errors.New("invalid signature")
+}


### PR DESCRIPTION
Signed-off-by: Hirokuni-Kitahara1 hirokuni.kitahara1@ibm.com

This PR aims to add `manifest-build` command to generate a YAML manifest with its provenance.

Based on the issue https://github.com/sigstore/k8s-manifest-sigstore/issues/25

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
