### PR TITLE
improve verify-resource speed with concurrency in go

### DIFF
--- a/cmd/kubectl-sigstore/verify_resource.go
+++ b/cmd/kubectl-sigstore/verify_resource.go
@@ -279,7 +279,7 @@ func verifyResource(yamls [][]byte, kubeGetArgs []string, imageRef, sigResRef, k
 	sem := semaphore.NewWeighted(concurrencyNum)
 	for i := range prepareFuncs {
 		pf := prepareFuncs[i]
-		sem.Acquire(context.Background(), 1)
+		_ = sem.Acquire(context.Background(), 1)
 		eg1.Go(func() error {
 			if pf.Type().Kind() != reflect.Func {
 				return fmt.Errorf("failed to call preparation function; this is not a function, but %s", pf.Type().Kind().String())
@@ -303,7 +303,7 @@ func verifyResource(yamls [][]byte, kubeGetArgs []string, imageRef, sigResRef, k
 	results := []resourceResult{}
 	for i := range objs {
 		obj := objs[i]
-		sem.Acquire(context.Background(), 1)
+		_ = sem.Acquire(context.Background(), 1)
 		eg2.Go(func() error {
 			log.Debug("checking kind: ", obj.GetKind(), ", name: ", obj.GetName())
 			vResult, err := k8smanifest.VerifyResource(obj, vo)
@@ -570,7 +570,7 @@ func getObjsByConstraint(constraintRef, matchField, inscopeField string, concurr
 		nsName := kindNamespaces[i][1]
 		kindResource := kinds[kindName]
 		nsObj := namespaces[nsName]
-		sem.Acquire(context.Background(), 1)
+		_ = sem.Acquire(context.Background(), 1)
 		eg1.Go(func() error {
 			tmpObjList, err := kubeutil.ListResources("", kindName, nsName)
 			if err != nil {

--- a/cmd/kubectl-sigstore/verify_resource.go
+++ b/cmd/kubectl-sigstore/verify_resource.go
@@ -661,7 +661,7 @@ func getObjsByConstraintWithCache(constraintRef, matchField, inscopeField string
 	if cacheFound {
 		return objs, err
 	} else {
-		objs, err = getObjsByConstraint(constraintRef, matchField, inscopeField)
+		objs, err = getObjsByConstraint(constraintRef, matchField, inscopeField, concurrencyNum)
 		cErr := k8ssigutil.SetCache(cacheKey, objs, err)
 		if cErr != nil {
 			log.Warnf("failed to save cache: %s", cErr.Error())

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/tektoncd/chains v0.3.0
 	github.com/theupdateframework/go-tuf v0.0.0-20210722233521-90e262754396
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.21.3
 	k8s.io/apimachinery v0.21.3

--- a/pkg/k8smanifest/verify_resource.go
+++ b/pkg/k8smanifest/verify_resource.go
@@ -49,7 +49,6 @@ func (r *VerifyResourceResult) String() string {
 }
 
 func VerifyResource(obj unstructured.Unstructured, vo *VerifyResourceOption) (*VerifyResourceResult, error) {
-	start := time.Now().UTC()
 	objBytes, _ := yaml.Marshal(obj.Object)
 
 	verified := false
@@ -100,14 +99,12 @@ func VerifyResource(obj unstructured.Unstructured, vo *VerifyResourceOption) (*V
 		}
 	}
 
-	preManifestFetch := time.Now().UTC()
 	var resourceManifests [][]byte
 	log.Debug("fetching manifest...")
 	resourceManifests, sigRef, err = NewManifestFetcher(imageRefString, sigResourceRefString, vo.AnnotationConfig, ignoreFields, vo.MaxResourceManifestNum).Fetch(objBytes)
 	if err != nil {
 		return nil, errors.Wrap(err, "YAML manifest not found for this resource")
 	}
-	preManifestMatch := time.Now().UTC()
 	log.Debug("matching object with manifest...")
 	var mnfMatched bool
 	var diff *mapnode.DiffResult
@@ -133,14 +130,12 @@ func VerifyResource(obj unstructured.Unstructured, vo *VerifyResourceOption) (*V
 		keyPath = &(vo.KeyPath)
 	}
 
-	preSignatureVerify := time.Now().UTC()
 	var sigVerified bool
 	log.Debug("verifying signature...")
 	sigVerified, signerName, signedTimestamp, err = NewSignatureVerifier(objBytes, sigRef, keyPath, vo.AnnotationConfig).Verify()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to verify signature")
 	}
-	postSignatureVerify := time.Now().UTC()
 
 	verified = mnfMatched && sigVerified && vo.Signers.Match(signerName)
 
@@ -156,14 +151,6 @@ func VerifyResource(obj unstructured.Unstructured, vo *VerifyResourceOption) (*V
 			return nil, errors.Wrap(err, "failed to get provenance")
 		}
 	}
-
-	finish := time.Now().UTC()
-	log.Infof("VR for obj kind: %s, name: %s, total time: %vs", obj.GetKind(), obj.GetName(), finish.Sub(start).Seconds())
-	log.Infof("VR for obj kind: %s, name: %s,   initialize: %vs", obj.GetKind(), obj.GetName(), preManifestFetch.Sub(start).Seconds())
-	log.Infof("VR for obj kind: %s, name: %s,   manifest-fetch: %vs", obj.GetKind(), obj.GetName(), preManifestMatch.Sub(preManifestFetch).Seconds())
-	log.Infof("VR for obj kind: %s, name: %s,   manifest-match: %vs", obj.GetKind(), obj.GetName(), preSignatureVerify.Sub(preManifestMatch).Seconds())
-	log.Infof("VR for obj kind: %s, name: %s,   signature-verify: %vs", obj.GetKind(), obj.GetName(), postSignatureVerify.Sub(preSignatureVerify).Seconds())
-	log.Infof("VR for obj kind: %s, name: %s,   provenance(if available): %vs", obj.GetKind(), obj.GetName(), finish.Sub(postSignatureVerify).Seconds())
 
 	return &VerifyResourceResult{
 		Verified:        verified,

--- a/pkg/k8smanifest/verify_resource.go
+++ b/pkg/k8smanifest/verify_resource.go
@@ -49,7 +49,7 @@ func (r *VerifyResourceResult) String() string {
 }
 
 func VerifyResource(obj unstructured.Unstructured, vo *VerifyResourceOption) (*VerifyResourceResult, error) {
-
+	start := time.Now().UTC()
 	objBytes, _ := yaml.Marshal(obj.Object)
 
 	verified := false
@@ -100,13 +100,14 @@ func VerifyResource(obj unstructured.Unstructured, vo *VerifyResourceOption) (*V
 		}
 	}
 
+	preManifestFetch := time.Now().UTC()
 	var resourceManifests [][]byte
 	log.Debug("fetching manifest...")
 	resourceManifests, sigRef, err = NewManifestFetcher(imageRefString, sigResourceRefString, vo.AnnotationConfig, ignoreFields, vo.MaxResourceManifestNum).Fetch(objBytes)
 	if err != nil {
 		return nil, errors.Wrap(err, "YAML manifest not found for this resource")
 	}
-
+	preManifestMatch := time.Now().UTC()
 	log.Debug("matching object with manifest...")
 	var mnfMatched bool
 	var diff *mapnode.DiffResult
@@ -132,12 +133,14 @@ func VerifyResource(obj unstructured.Unstructured, vo *VerifyResourceOption) (*V
 		keyPath = &(vo.KeyPath)
 	}
 
+	preSignatureVerify := time.Now().UTC()
 	var sigVerified bool
 	log.Debug("verifying signature...")
 	sigVerified, signerName, signedTimestamp, err = NewSignatureVerifier(objBytes, sigRef, keyPath, vo.AnnotationConfig).Verify()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to verify signature")
 	}
+	postSignatureVerify := time.Now().UTC()
 
 	verified = mnfMatched && sigVerified && vo.Signers.Match(signerName)
 
@@ -153,6 +156,14 @@ func VerifyResource(obj unstructured.Unstructured, vo *VerifyResourceOption) (*V
 			return nil, errors.Wrap(err, "failed to get provenance")
 		}
 	}
+
+	finish := time.Now().UTC()
+	log.Infof("VR for obj kind: %s, name: %s, total time: %vs", obj.GetKind(), obj.GetName(), finish.Sub(start).Seconds())
+	log.Infof("VR for obj kind: %s, name: %s,   initialize: %vs", obj.GetKind(), obj.GetName(), preManifestFetch.Sub(start).Seconds())
+	log.Infof("VR for obj kind: %s, name: %s,   manifest-fetch: %vs", obj.GetKind(), obj.GetName(), preManifestMatch.Sub(preManifestFetch).Seconds())
+	log.Infof("VR for obj kind: %s, name: %s,   manifest-match: %vs", obj.GetKind(), obj.GetName(), preSignatureVerify.Sub(preManifestMatch).Seconds())
+	log.Infof("VR for obj kind: %s, name: %s,   signature-verify: %vs", obj.GetKind(), obj.GetName(), postSignatureVerify.Sub(preSignatureVerify).Seconds())
+	log.Infof("VR for obj kind: %s, name: %s,   provenance(if available): %vs", obj.GetKind(), obj.GetName(), finish.Sub(postSignatureVerify).Seconds())
 
 	return &VerifyResourceResult{
 		Verified:        verified,

--- a/pkg/util/cache.go
+++ b/pkg/util/cache.go
@@ -21,16 +21,13 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-<<<<<<< HEAD
 	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
-=======
 	"sync"
->>>>>>> 5ea58a8 (update xonxurrency)
 	"time"
 )
 

--- a/pkg/util/cache.go
+++ b/pkg/util/cache.go
@@ -120,7 +120,7 @@ type LocalFileCache struct {
 
 func (c *LocalFileCache) Set(key string, value ...interface{}) error {
 	if !c.baseDirExists() {
-		c.initBaseDir()
+		_ = c.initBaseDir()
 	}
 	if c.mem == nil {
 		c.mem = c.initMem()
@@ -144,12 +144,12 @@ func (c *LocalFileCache) Set(key string, value ...interface{}) error {
 
 func (c *LocalFileCache) Get(key string) ([]interface{}, error) {
 	if !c.baseDirExists() {
-		c.initBaseDir()
+		_ = c.initBaseDir()
 	}
 	if c.mem == nil {
 		c.mem = c.initMem()
 	}
-	c.clearExpiredData()
+	_ = c.clearExpiredData()
 
 	value1, err := c.mem.Get(key)
 	if err == nil {


### PR DESCRIPTION
Signed-off-by: Hirokuni-Kitahara1 hirokuni.kitahara1@ibm.com

- split verify-resource command steps into 2 major steps, `initialize` and `verify-resource`
- apply concurrent execution to both of these 2 steps so that it could reduce the time to complete the command
- add a few log outputs to verify-resource command

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
