### PR TITLE
enable local file cache for verify-resource speed up

### DIFF
--- a/cmd/kubectl-sigstore/verify_resource.go
+++ b/cmd/kubectl-sigstore/verify_resource.go
@@ -524,11 +524,10 @@ func getObjsByConstraintMatchConditionWithCache(constraintRef, matchField, insco
 		if results[0] != nil {
 			var ok bool
 			if objs, ok = results[0].([]unstructured.Unstructured); !ok {
-				tmpObjIfs := results[0].([]interface{})
-				objs = []unstructured.Unstructured{}
-				for _, tmpObjIf := range tmpObjIfs {
-					tmpObj := tmpObjIf.(unstructured.Unstructured)
-					objs = append(objs, tmpObj)
+				objsBytes, _ := json.Marshal(results[0])
+				var tmpObjs []unstructured.Unstructured
+				if err = json.Unmarshal(objsBytes, &tmpObjs); err != nil {
+					objs = tmpObjs
 				}
 			}
 		}

--- a/cmd/kubectl-sigstore/verify_resource.go
+++ b/cmd/kubectl-sigstore/verify_resource.go
@@ -522,7 +522,15 @@ func getObjsByConstraintMatchConditionWithCache(constraintRef, matchField, insco
 	}
 	if cacheFound {
 		if results[0] != nil {
-			objs = results[0].([]unstructured.Unstructured)
+			var ok bool
+			if objs, ok = results[0].([]unstructured.Unstructured); !ok {
+				tmpObjIfs := results[0].([]interface{})
+				objs = []unstructured.Unstructured{}
+				for _, tmpObjIf := range tmpObjIfs {
+					tmpObj := tmpObjIf.(unstructured.Unstructured)
+					objs = append(objs, tmpObj)
+				}
+			}
 		}
 		if results[1] != nil {
 			err = results[1].(error)

--- a/cmd/kubectl-sigstore/verify_resource.go
+++ b/cmd/kubectl-sigstore/verify_resource.go
@@ -518,9 +518,6 @@ func getObjsByConstraintMatchConditionWithCache(constraintRef, matchField, insco
 		if len(results) != resultNum {
 			return nil, fmt.Errorf("cache has inconsistent data: a length of results must be %v, but got %v", resultNum, len(results))
 		}
-		cacheFound = true
-	}
-	if cacheFound {
 		if results[0] != nil {
 			var ok bool
 			if objs, ok = results[0].([]unstructured.Unstructured); !ok {
@@ -528,12 +525,19 @@ func getObjsByConstraintMatchConditionWithCache(constraintRef, matchField, insco
 				var tmpObjs []unstructured.Unstructured
 				if err = json.Unmarshal(objsBytes, &tmpObjs); err != nil {
 					objs = tmpObjs
+				} else {
+					log.Warnf("failed to unmarshal target object cache: %s", err.Error())
 				}
 			}
 		}
 		if results[1] != nil {
 			err = results[1].(error)
 		}
+		if objs != nil || err != nil {
+			cacheFound = true
+		}
+	}
+	if cacheFound {
 		return objs, err
 	} else {
 		objs, err = getObjsByConstraintMatchCondition(constraintRef, matchField, inscopeField)

--- a/cmd/kubectl-sigstore/verify_resource.go
+++ b/cmd/kubectl-sigstore/verify_resource.go
@@ -190,7 +190,7 @@ func verifyResource(yamls [][]byte, kubeGetArgs []string, imageRef, sigResRef, k
 
 	objs := []unstructured.Unstructured{}
 	if configType == configTypeConstraint {
-		objs, err = getObjsByConstraintMatchConditionWithCache(configPath, defaultMatchFieldPathConstraint, defaultInScopeObjectParameterFieldPathConstraint)
+		objs, err = getObjsByConstraintWithCache(configPath, defaultMatchFieldPathConstraint, defaultInScopeObjectParameterFieldPathConstraint)
 	} else if len(kubeGetArgs) > 0 {
 		objs, err = kubectlOptions.Get(kubeGetArgs, "")
 	} else if yamls != nil {
@@ -372,7 +372,7 @@ func getObjsFromManifests(yamls [][]byte, ignoreFieldConfig k8smanifest.ObjectFi
 // 4. check ExcludeNamespace conditions if exist
 // 5. list existing resources by kind in a namespace. do this for all selected kinds and namespaces
 // 6. check inScopeOpject condition if exists
-func getObjsByConstraintMatchCondition(constraintRef, matchField, inscopeField string) ([]unstructured.Unstructured, error) {
+func getObjsByConstraint(constraintRef, matchField, inscopeField string) ([]unstructured.Unstructured, error) {
 	// step 1
 	// get Constraint resource from cluster and extract its gatekeeper match condition and `inScopeObjects` in parameters
 	constraintMatch, inScopeObjectCondition, err := k8smanifest.GetMatchConditionFromConfigResource(constraintRef, matchField, inscopeField)
@@ -507,10 +507,10 @@ func getObjsByConstraintMatchCondition(constraintRef, matchField, inscopeField s
 	return objs, nil
 }
 
-func getObjsByConstraintMatchConditionWithCache(constraintRef, matchField, inscopeField string) ([]unstructured.Unstructured, error) {
+func getObjsByConstraintWithCache(constraintRef, matchField, inscopeField string) ([]unstructured.Unstructured, error) {
 	var objs []unstructured.Unstructured
 	var err error
-	cacheKey := fmt.Sprintf("targetObjects/constraint/%s", constraintRef)
+	cacheKey := fmt.Sprintf("getObjsByConstraint/%s", constraintRef)
 	resultNum := 2
 	results, err := k8ssigutil.GetCache(cacheKey)
 	cacheFound := false
@@ -523,7 +523,7 @@ func getObjsByConstraintMatchConditionWithCache(constraintRef, matchField, insco
 			if objs, ok = results[0].([]unstructured.Unstructured); !ok {
 				objsBytes, _ := json.Marshal(results[0])
 				var tmpObjs []unstructured.Unstructured
-				if err = json.Unmarshal(objsBytes, &tmpObjs); err != nil {
+				if err = json.Unmarshal(objsBytes, &tmpObjs); err == nil {
 					objs = tmpObjs
 				} else {
 					log.Warnf("failed to unmarshal target object cache: %s", err.Error())
@@ -540,7 +540,7 @@ func getObjsByConstraintMatchConditionWithCache(constraintRef, matchField, insco
 	if cacheFound {
 		return objs, err
 	} else {
-		objs, err = getObjsByConstraintMatchCondition(constraintRef, matchField, inscopeField)
+		objs, err = getObjsByConstraint(constraintRef, matchField, inscopeField)
 		cErr := k8ssigutil.SetCache(cacheKey, objs, err)
 		if cErr != nil {
 			log.Warnf("failed to save cache: %s", cErr.Error())

--- a/pkg/k8smanifest/provenance.go
+++ b/pkg/k8smanifest/provenance.go
@@ -303,7 +303,13 @@ func (g *ImageProvenanceGetter) getAttestation() ([]byte, *int, error) {
 				}
 			}
 			if results[2] != nil {
-				err = results[2].(error)
+				var ok bool
+				if err, ok = results[2].(error); !ok {
+					errMap := results[2].(map[string]interface{})
+					if errBytes, mErr := json.Marshal(errMap); mErr == nil {
+						err = errors.New(string(errBytes))
+					}
+				}
 			}
 		} else {
 			log.Debug("attestation cache not found for image: ", g.imageRef, ", hash: ", g.imageHash)

--- a/pkg/k8smanifest/verify.go
+++ b/pkg/k8smanifest/verify.go
@@ -20,6 +20,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -37,10 +39,18 @@ import (
 
 const SigRefEmbeddedInAnnotation = "__embedded_in_annotation__"
 
-var onMemoryCacheForVerifyResource *k8smnfutil.OnMemoryCache
+var cacheForVerifyResource k8smnfutil.Cache
+var localCacheEnvKey = "K8S_MANIFEST_LOCAL_FILE_CACHE"
 
 func init() {
-	onMemoryCacheForVerifyResource = &k8smnfutil.OnMemoryCache{TTL: 30 * time.Second}
+	localFileCache, _ := strconv.ParseBool(os.Getenv(localCacheEnvKey))
+	if localFileCache {
+		cacheForVerifyResource = &k8smnfutil.LocalFileCache{TTL: 180 * time.Second}
+		cacheForProvenance = &k8smnfutil.LocalFileCache{TTL: 180 * time.Second}
+	} else {
+		cacheForVerifyResource = &k8smnfutil.OnMemoryCache{TTL: 30 * time.Second}
+		cacheForProvenance = &k8smnfutil.OnMemoryCache{TTL: 30 * time.Second}
+	}
 }
 
 type SignatureVerifier interface {
@@ -106,8 +116,8 @@ func (v *ImageSignatureVerifier) Verify() (bool, string, *int64, error) {
 		allErrs := []string{}
 		for i := range pubkeys {
 			pubkey := pubkeys[i]
-			// try getting result from on-memory cache
-			cacheFound, verified, signerName, signedTimestamp, err = v.getResultFromMemCache(imageRef, pubkey)
+			// try getting result from cache
+			cacheFound, verified, signerName, signedTimestamp, err = v.getResultFromCache(imageRef, pubkey)
 			// if found and verified true, return it
 			if cacheFound {
 				cacheFoundCount += 1
@@ -132,8 +142,8 @@ func (v *ImageSignatureVerifier) Verify() (bool, string, *int64, error) {
 		verified, signerName, signedTimestamp, err = k8smnfcosign.VerifyImage(imageRef, pubkey)
 
 		if v.onMemoryCacheEnabled {
-			// set the result to on-memory cache
-			v.setResultToMemCache(imageRef, pubkey, verified, signerName, signedTimestamp, err)
+			// set the result to cache
+			v.setResultToCache(imageRef, pubkey, verified, signerName, signedTimestamp, err)
 		}
 
 		if verified {
@@ -145,10 +155,10 @@ func (v *ImageSignatureVerifier) Verify() (bool, string, *int64, error) {
 	return false, "", nil, fmt.Errorf("signature verification failed: %s", strings.Join(allErrs, "; "))
 }
 
-func (v *ImageSignatureVerifier) getResultFromMemCache(imageRef, pubkey string) (bool, bool, string, *int64, error) {
+func (v *ImageSignatureVerifier) getResultFromCache(imageRef, pubkey string) (bool, bool, string, *int64, error) {
 	key := fmt.Sprintf("cache/verify-image/%s/%s", imageRef, pubkey)
 	resultNum := 4
-	result, err := onMemoryCacheForVerifyResource.Get(key)
+	result, err := cacheForVerifyResource.Get(key)
 	if err != nil {
 		// OnMemoryCache.Get() returns an error only when the key was not found
 		return false, false, "", nil, nil
@@ -174,9 +184,12 @@ func (v *ImageSignatureVerifier) getResultFromMemCache(imageRef, pubkey string) 
 	return true, verified, signerName, signedTimestamp, err
 }
 
-func (v *ImageSignatureVerifier) setResultToMemCache(imageRef, pubkey string, verified bool, signerName string, signedTimestamp *int64, err error) {
+func (v *ImageSignatureVerifier) setResultToCache(imageRef, pubkey string, verified bool, signerName string, signedTimestamp *int64, err error) {
 	key := fmt.Sprintf("cache/verify-image/%s/%s", imageRef, pubkey)
-	_ = onMemoryCacheForVerifyResource.Set(key, verified, signerName, signedTimestamp, err)
+	setErr := cacheForVerifyResource.Set(key, verified, signerName, signedTimestamp, err)
+	if setErr != nil {
+		log.Warn("cache set error: ", setErr.Error())
+	}
 }
 
 type BlobSignatureVerifier struct {
@@ -275,7 +288,7 @@ type ManifestFetcher interface {
 // `ignoreFields` and `maxResourceManifestNum` are used inside manifest detection logic.
 func NewManifestFetcher(imageRef, resourceRef string, annotationConfig AnnotationConfig, ignoreFields []string, maxResourceManifestNum int) ManifestFetcher {
 	if imageRef != "" {
-		return &ImageManifestFetcher{imageRefString: imageRef, AnnotationConfig: annotationConfig, ignoreFields: ignoreFields, maxResourceManifestNum: maxResourceManifestNum, onMemoryCacheEnabled: true}
+		return &ImageManifestFetcher{imageRefString: imageRef, AnnotationConfig: annotationConfig, ignoreFields: ignoreFields, maxResourceManifestNum: maxResourceManifestNum, cacheEnabled: true}
 	} else {
 		return &BlobManifestFetcher{AnnotationConfig: annotationConfig, resourceRefString: resourceRef, ignoreFields: ignoreFields, maxResourceManifestNum: maxResourceManifestNum}
 	}
@@ -287,7 +300,7 @@ type ImageManifestFetcher struct {
 	AnnotationConfig       AnnotationConfig
 	ignoreFields           []string // used by ManifestSearchByValue()
 	maxResourceManifestNum int      // used by ManifestSearchByValue()
-	onMemoryCacheEnabled   bool
+	cacheEnabled           bool
 }
 
 func (f *ImageManifestFetcher) Fetch(objYAMLBytes []byte) ([][]byte, string, error) {
@@ -325,18 +338,18 @@ func (f *ImageManifestFetcher) Fetch(objYAMLBytes []byte) ([][]byte, string, err
 func (f *ImageManifestFetcher) fetchManifestInSingleImage(singleImageRef string) ([]byte, error) {
 	var concatYAMLbytes []byte
 	var err error
-	if f.onMemoryCacheEnabled {
+	if f.cacheEnabled {
 		cacheFound := false
-		// try getting YAML manifests from on-memory cache
-		cacheFound, concatYAMLbytes, err = f.getManifestFromMemCache(singleImageRef)
+		// try getting YAML manifests from cache
+		cacheFound, concatYAMLbytes, err = f.getManifestFromCache(singleImageRef)
 		// if cache not found, do fetch and set the result to cache
 		if !cacheFound {
 			log.Debug("image manifest cache not found")
 			// fetch YAML manifests from actual image
 			concatYAMLbytes, err = f.getConcatYAMLFromImageRef(singleImageRef)
 			if err == nil {
-				// set the result to on-memory cache
-				f.setManifestToMemCache(singleImageRef, concatYAMLbytes, err)
+				// set the result to cache
+				f.setManifestToCache(singleImageRef, concatYAMLbytes, err)
 			}
 		}
 	} else {
@@ -377,10 +390,10 @@ func (f *ImageManifestFetcher) getConcatYAMLFromImageRef(imageRef string) ([]byt
 	return concatYAMLbytes, nil
 }
 
-func (f *ImageManifestFetcher) getManifestFromMemCache(imageRef string) (bool, []byte, error) {
+func (f *ImageManifestFetcher) getManifestFromCache(imageRef string) (bool, []byte, error) {
 	key := fmt.Sprintf("cache/fetch-manifest/%s", imageRef)
 	resultNum := 2
-	result, err := onMemoryCacheForVerifyResource.Get(key)
+	result, err := cacheForVerifyResource.Get(key)
 	if err != nil {
 		// OnMemoryCache.Get() returns an error only when the key was not found
 		return false, nil, nil
@@ -390,7 +403,13 @@ func (f *ImageManifestFetcher) getManifestFromMemCache(imageRef string) (bool, [
 	}
 	var concatYAMLbytes []byte
 	if result[0] != nil {
-		concatYAMLbytes = result[0].([]byte)
+		var ok bool
+		if concatYAMLbytes, ok = result[0].([]byte); !ok {
+			concatYAMLStr := result[0].(string)
+			if tmpYAMLbytes, err := base64.StdEncoding.DecodeString(concatYAMLStr); err == nil {
+				concatYAMLbytes = tmpYAMLbytes
+			}
+		}
 	}
 	if result[1] != nil {
 		err = result[1].(error)
@@ -398,9 +417,12 @@ func (f *ImageManifestFetcher) getManifestFromMemCache(imageRef string) (bool, [
 	return true, concatYAMLbytes, err
 }
 
-func (f *ImageManifestFetcher) setManifestToMemCache(imageRef string, concatYAMLbytes []byte, err error) {
+func (f *ImageManifestFetcher) setManifestToCache(imageRef string, concatYAMLbytes []byte, err error) {
 	key := fmt.Sprintf("cache/fetch-manifest/%s", imageRef)
-	_ = onMemoryCacheForVerifyResource.Set(key, concatYAMLbytes, err)
+	setErr := cacheForVerifyResource.Set(key, concatYAMLbytes, err)
+	if setErr != nil {
+		log.Warn("cache set error: ", setErr.Error())
+	}
 }
 
 type BlobManifestFetcher struct {

--- a/pkg/util/cache.go
+++ b/pkg/util/cache.go
@@ -17,11 +17,29 @@
 package util
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
 	"time"
 )
 
+// ensure these implement Cache interface
 var _ Cache = &OnMemoryCache{}
+var _ Cache = &LocalFileCache{}
+
+type CacheType string
+
+const (
+	CacheTypeUnknown CacheType = ""
+	CacheTypeMemory  CacheType = "memory"
+	CacheTypeFile    CacheType = "file"
+)
 
 type Cache interface {
 	Set(key string, value ...interface{}) error
@@ -77,4 +95,124 @@ func (c *OnMemoryCache) clearExpiredData() {
 		newData[key] = obj
 	}
 	c.data = newData
+}
+
+type LocalFileCache struct {
+	TTL     time.Duration
+	baseDir string
+
+	mem *OnMemoryCache
+}
+
+func (c *LocalFileCache) Set(key string, value ...interface{}) error {
+	if !c.baseDirExists() {
+		c.initBaseDir()
+	}
+	if c.mem == nil {
+		c.mem = c.initMem()
+	}
+	err := c.mem.Set(key, value...)
+	if err != nil {
+		return err
+	}
+
+	fpath := c.genFileNameFromKey(key)
+	valueBytes, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(fpath, valueBytes, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *LocalFileCache) Get(key string) ([]interface{}, error) {
+	if !c.baseDirExists() {
+		c.initBaseDir()
+	}
+	if c.mem == nil {
+		c.mem = c.initMem()
+	}
+	c.clearExpiredData()
+
+	value1, err := c.mem.Get(key)
+	if err == nil {
+		return value1, nil
+	}
+
+	fpath := c.genFileNameFromKey(key)
+	valueBytes, err := ioutil.ReadFile(fpath)
+	if err != nil {
+		return nil, err
+	}
+	var value2 []interface{}
+	err = json.Unmarshal(valueBytes, &value2)
+	if err != nil {
+		return nil, err
+	}
+	return value2, nil
+}
+
+// generate a filename from a key
+func (c *LocalFileCache) genFileNameFromKey(key string) string {
+	keyHash := sha256.Sum256([]byte(key))
+	fname := base64.StdEncoding.EncodeToString(keyHash[:])
+	fname = strings.ReplaceAll(fname, "=", "")
+	fname = strings.ReplaceAll(fname, "/", "")
+	fname = strings.ReplaceAll(fname, "+", "")
+	fpath := filepath.Join(c.baseDir, fname)
+	return fpath
+}
+
+func (c *LocalFileCache) initBaseDir() error {
+	if c.baseDir == "" {
+		c.baseDir = GetCacheBaseDir()
+	}
+	return os.MkdirAll(c.baseDir, 0777)
+}
+
+func (c *LocalFileCache) baseDirExists() bool {
+	if c.baseDir == "" {
+		c.baseDir = GetCacheBaseDir()
+	}
+	_, err := os.Stat(c.baseDir)
+	return err == nil
+}
+func (c *LocalFileCache) clearExpiredData() error {
+	if c.mem == nil {
+		c.mem = c.initMem()
+	}
+	c.mem.clearExpiredData()
+
+	var err error
+	var fds []os.FileInfo
+	if fds, err = ioutil.ReadDir(c.baseDir); err != nil {
+		return err
+	}
+	for _, fd := range fds {
+		if fd.IsDir() {
+			continue
+		} else {
+			fname := path.Join(c.baseDir, fd.Name())
+			modTime := fd.ModTime().UTC()
+			now := time.Now().UTC()
+			if now.Sub(modTime) > c.TTL {
+				err = os.Remove(fname)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (c *LocalFileCache) initMem() *OnMemoryCache {
+	return &OnMemoryCache{TTL: c.TTL, data: map[string]cachedObject{}}
+}
+
+func GetCacheBaseDir() string {
+	return filepath.Join(GetHomeDir(), ".sigstore", "k8smanifest", "cache")
 }

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -285,3 +285,11 @@ func IsDir(path string) (bool, error) {
 	}
 	return fi.IsDir(), nil
 }
+
+func GetHomeDir() string {
+	dir, err := os.UserHomeDir()
+	if err != nil {
+		dir = "/root"
+	}
+	return dir
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,0 +1,21 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package util
+
+func init() {
+	initGlobalCache()
+}


### PR DESCRIPTION
Signed-off-by: Hirokuni-Kitahara1 hirokuni.kitahara1@ibm.com

- enable local file cache for further speed up after enabling concurrency
  - use *K8S_MANIFEST_LOCAL_FILE_CACHE=1* env variable for the flag of this feature
- refactor cache initialization




<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
