### PR TITLE
add `--image-verify` option for verifying container images

### DIFF
--- a/cmd/kubectl-sigstore/verify_resource.go
+++ b/cmd/kubectl-sigstore/verify_resource.go
@@ -295,6 +295,10 @@ func verifyResource(yamls [][]byte, kubeGetArgs []string, imageRef, sigResRef, k
 		return false, errors.Wrap(err, "error in executing preparaction for verify-resource")
 	}
 
+	if outputFormat == "" {
+		log.Info("verifying the resources.")
+	}
+	// execute verify-resource by using prepared cache
 	preVerifyResource := time.Now().UTC()
 	eg2 := errgroup.Group{}
 	mutex := sync.Mutex{}

--- a/pkg/k8smanifest/option.go
+++ b/pkg/k8smanifest/option.go
@@ -50,12 +50,18 @@ type SignOption struct {
 	ApplySigConfigMap bool                   `json:"-"`
 }
 
+// option for VerifyImage()
+type VerifyImageOption struct {
+	KeyPath       string             `json:"keyPath"`
+	InScopeImages ImageReferenceList `json:"inScopeImages,omitempty"` // if empty, match all
+	Signers       SignerList         `json:"signers,omitempty"`       // if emprt, match all
+}
+
 // option for VerifyResource()
 type VerifyResourceOption struct {
-	commonOption      `json:""`
-	verifyOption      `json:""`
-	SkipObjects       ObjectReferenceList `json:"skipObjects,omitempty"`
-	ImageVerification ImageVerifyOption   `json:"imageVerification,omitempty"`
+	commonOption `json:""`
+	verifyOption `json:""`
+	SkipObjects  ObjectReferenceList `json:"skipObjects,omitempty"`
 
 	Provenance          bool   `json:"-"`
 	CheckDryRunForApply bool   `json:"-"`
@@ -80,13 +86,6 @@ func (o *VerifyManifestOption) SetAnnotationIgnoreFields() {
 		return
 	}
 	o.verifyOption = o.verifyOption.setAnnotationKeyToIgnoreField(o.AnnotationConfig)
-}
-
-type ImageVerifyOption struct {
-	Enabled       bool               `json:"enabled,omitempty"`
-	KeyPath       string             `json:"keyPath"`
-	InScopeImages ImageReferenceList `json:"inScopeImages,omitempty"` // if empty, match all
-	Signers       SignerList         `json:"signers,omitempty"`       // if emprt, match all
 }
 
 // common options for verify functions

--- a/pkg/k8smanifest/verify_image.go
+++ b/pkg/k8smanifest/verify_image.go
@@ -1,0 +1,109 @@
+//
+// Copyright 2020 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package k8smanifest
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/pkg/errors"
+	"github.com/sigstore/k8s-manifest-sigstore/pkg/cosign"
+	kubeutil "github.com/sigstore/k8s-manifest-sigstore/pkg/util/kubeutil"
+)
+
+type VerifyImageResult struct {
+	Images []SingleImageResult `json:"images"`
+
+	numInScopeImages  int `json:"-"`
+	numVerifiedImages int `json:"-"`
+}
+
+type SingleImageResult struct {
+	kubeutil.ImageObject `json:""`
+	Verified             bool       `json:"verified"`
+	InScope              bool       `json:"inScope"`
+	Signer               string     `json:"signer"`
+	SignedTime           *time.Time `json:"signedTime"`
+	FailedReason         string     `json:"failedReason"`
+}
+
+// verify all images inside a specified resource object
+// e.g.) if obj is a Pod, list all the container images in the Pod and try verifying signatures of them
+func VerifyImage(obj unstructured.Unstructured, vo *VerifyImageOption) (*VerifyImageResult, error) {
+	images, err := kubeutil.GetAllImagesFromObject(&obj)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get images in object")
+	}
+	if vo == nil {
+		return nil, errors.New("VerifyImageOption must be non-nil value")
+	}
+	results := []SingleImageResult{}
+	numInScope := 0
+	numVerified := 0
+	for _, img := range images {
+		inScope := vo.InScopeImages.Match(img.ImageRef)
+		if !inScope {
+			r := SingleImageResult{
+				ImageObject: img,
+				InScope:     false,
+			}
+			results = append(results, r)
+			continue
+		}
+		sigVerified, signerName, _, err := cosign.VerifyImage(img.ImageRef, vo.KeyPath)
+		failedReason := ""
+		if !sigVerified && err != nil {
+			failedReason = err.Error()
+		}
+		signerOk := true
+		if sigVerified {
+			signerOk = vo.Signers.Match(signerName)
+		}
+		verified := sigVerified && signerOk
+
+		if inScope {
+			numInScope += 1
+		}
+		if verified {
+			numVerified += 1
+		}
+		r := SingleImageResult{
+			ImageObject:  img,
+			Verified:     verified,
+			InScope:      true,
+			Signer:       signerName,
+			FailedReason: failedReason,
+		}
+		results = append(results, r)
+	}
+
+	verifyResult := &VerifyImageResult{
+		Images:            results,
+		numInScopeImages:  numInScope,
+		numVerifiedImages: numVerified,
+	}
+	return verifyResult, nil
+}
+
+func (r *VerifyImageResult) Verified() bool {
+	return r.numInScopeImages == r.numVerifiedImages
+}
+
+func (r *VerifyImageResult) ImageFound() bool {
+	return len(r.Images) > 0
+}

--- a/pkg/k8smanifest/verify_resource.go
+++ b/pkg/k8smanifest/verify_resource.go
@@ -99,6 +99,7 @@ func VerifyResource(obj unstructured.Unstructured, vo *VerifyResourceOption) (*V
 		}
 	}
 
+	preManifestFetch := time.Now().UTC()
 	var resourceManifests [][]byte
 	log.Debug("fetching manifest...")
 	resourceManifests, sigRef, err = NewManifestFetcher(imageRefString, sigResourceRefString, vo.AnnotationConfig, ignoreFields, vo.MaxResourceManifestNum).Fetch(objBytes)
@@ -130,12 +131,14 @@ func VerifyResource(obj unstructured.Unstructured, vo *VerifyResourceOption) (*V
 		keyPath = &(vo.KeyPath)
 	}
 
+	preSignatureVerify := time.Now().UTC()
 	var sigVerified bool
 	log.Debug("verifying signature...")
 	sigVerified, signerName, signedTimestamp, err = NewSignatureVerifier(objBytes, sigRef, keyPath, vo.AnnotationConfig).Verify()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to verify signature")
 	}
+	postSignatureVerify := time.Now().UTC()
 
 	verified = mnfMatched && sigVerified && vo.Signers.Match(signerName)
 
@@ -151,6 +154,14 @@ func VerifyResource(obj unstructured.Unstructured, vo *VerifyResourceOption) (*V
 			return nil, errors.Wrap(err, "failed to get provenance")
 		}
 	}
+
+	finish := time.Now().UTC()
+	log.Infof("VR for obj kind: %s, name: %s, total time: %vs", obj.GetKind(), obj.GetName(), finish.Sub(start).Seconds())
+	log.Infof("VR for obj kind: %s, name: %s,   initialize: %vs", obj.GetKind(), obj.GetName(), preManifestFetch.Sub(start).Seconds())
+	log.Infof("VR for obj kind: %s, name: %s,   manifest-fetch: %vs", obj.GetKind(), obj.GetName(), preManifestMatch.Sub(preManifestFetch).Seconds())
+	log.Infof("VR for obj kind: %s, name: %s,   manifest-match: %vs", obj.GetKind(), obj.GetName(), preSignatureVerify.Sub(preManifestMatch).Seconds())
+	log.Infof("VR for obj kind: %s, name: %s,   signature-verify: %vs", obj.GetKind(), obj.GetName(), postSignatureVerify.Sub(preSignatureVerify).Seconds())
+	log.Infof("VR for obj kind: %s, name: %s,   provenance(if available): %vs", obj.GetKind(), obj.GetName(), finish.Sub(postSignatureVerify).Seconds())
 
 	return &VerifyResourceResult{
 		Verified:        verified,

--- a/pkg/k8smanifest/verify_resource.go
+++ b/pkg/k8smanifest/verify_resource.go
@@ -33,14 +33,23 @@ import (
 const defaultDryRunNamespace = "default"
 
 type VerifyResourceResult struct {
-	Verified        bool                   `json:"verified"`
-	InScope         bool                   `json:"inScope"`
-	Signer          string                 `json:"signer"`
-	SignedTime      *time.Time             `json:"signedTime"`
-	SigRef          string                 `json:"sigRef"`
-	Diff            *mapnode.DiffResult    `json:"diff"`
-	ContainerImages []kubeutil.ImageObject `json:"containerImages"`
-	Provenances     []*Provenance          `json:"provenances,omitempty"`
+	Verified           bool                   `json:"verified"`
+	InScope            bool                   `json:"inScope"`
+	Signer             string                 `json:"signer"`
+	SignedTime         *time.Time             `json:"signedTime"`
+	SigRef             string                 `json:"sigRef"`
+	Diff               *mapnode.DiffResult    `json:"diff"`
+	ContainerImages    []kubeutil.ImageObject `json:"containerImages"`
+	ImageVerifyResults []ImageResult          `json:"imageResults"`
+	Provenances        []*Provenance          `json:"provenances,omitempty"`
+}
+
+type ImageResult struct {
+	kubeutil.ImageObject `json:""`
+	Verified             bool       `json:"verified"`
+	InScope              bool       `json:"inScope"`
+	Signer               string     `json:"signer"`
+	SignedTime           *time.Time `json:"signedTime"`
 }
 
 func (r *VerifyResourceResult) String() string {
@@ -144,6 +153,34 @@ func VerifyResource(obj unstructured.Unstructured, vo *VerifyResourceOption) (*V
 		return nil, errors.Wrap(err, "failed to get container images")
 	}
 
+	imgSigResult := []ImageResult{}
+	if vo.ImageVerification.Enabled {
+		var imgKeyPath *string
+		if vo.ImageVerification.KeyPath != "" {
+			imgKeyPath = &(vo.ImageVerification.KeyPath)
+		} else if vo.KeyPath != "" {
+			imgKeyPath = &(vo.KeyPath)
+		}
+		for _, cimage := range containerImages {
+			inScope := vo.ImageVerification.InScopeImages.Match(cimage.ImageRef)
+			optionBytes, _ := json.Marshal(vo.ImageVerification.InScopeImages)
+			log.Debugf("[DEBUG] imageRef: %s, inScope: %v, option: %s", cimage.ImageRef, inScope, string(optionBytes))
+			imgSigVerified, imgSignerName, imgSignedTimestamp, err := NewSignatureVerifier(nil, cimage.ImageRef, imgKeyPath, vo.AnnotationConfig).Verify()
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to verify image signature")
+			}
+			imgVerified := imgSigVerified && vo.ImageVerification.Signers.Match(imgSignerName)
+			tmpResult := ImageResult{
+				ImageObject: cimage,
+				Verified:    imgVerified,
+				InScope:     inScope,
+				Signer:      imgSignerName,
+				SignedTime:  getTime(imgSignedTimestamp),
+			}
+			imgSigResult = append(imgSigResult, tmpResult)
+		}
+	}
+
 	provenances := []*Provenance{}
 	if vo.Provenance {
 		provenances, err = NewProvenanceGetter(&obj, sigRef, "", vo.ProvenanceResourceRef).Get()
@@ -153,14 +190,15 @@ func VerifyResource(obj unstructured.Unstructured, vo *VerifyResourceOption) (*V
 	}
 
 	return &VerifyResourceResult{
-		Verified:        verified,
-		InScope:         inScope,
-		Signer:          signerName,
-		SignedTime:      getTime(signedTimestamp),
-		SigRef:          sigRef,
-		Diff:            diff,
-		ContainerImages: containerImages,
-		Provenances:     provenances,
+		Verified:           verified,
+		InScope:            inScope,
+		Signer:             signerName,
+		SignedTime:         getTime(signedTimestamp),
+		SigRef:             sigRef,
+		Diff:               diff,
+		ContainerImages:    containerImages,
+		ImageVerifyResults: imgSigResult,
+		Provenances:        provenances,
 	}, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Hirokuni-Kitahara1 hirokuni.kitahara1@ibm.com

- when `--image-verify` flag is enabled in verify-resource command, the command verifies not only the specified resources but also container images of those resources.

Example:
```
$ kubectl sigstore verify-resource deployment sample-app --image-verify

...

[RESOURCES]
KIND         NAME         VALID   ERROR   AGE
Deployment   sample-app   true            5d

[RESOURCES - PODS/CONTAINERS]
POD                          CONTAINER    IMAGE ID                     SIGNED   SIGNER
sample-app-b494cd9c8-m7lmz   nginx        nginx:latest@IMAGE_DIGEST    true     sample-signer@example.com

```

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
