### PR TITLE
enable `version` command to show version of the executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,19 @@
 
+VERSION_PKG ?= github.com/sigstore/k8s-manifest-sigstore/pkg/util
+
 .PHONY: build
 
 build:
 	@echo building binary for cli
 	go mod tidy
-	CGO_ENABLED=0 GOARCH=amd64 GO111MODULE=on go build -ldflags="-s -w" -a -o kubectl-sigstore ./cmd/kubectl-sigstore
+	git_status=$$(git status --porcelain --untracked=no 2>/dev/null) && \
+	git_tree_state="dirty"  && \
+	if [[ -z "$$git_status" ]]; then \
+		git_tree_state="clean"; \
+	fi && \
+	CGO_ENABLED=0 GOARCH=amd64 GO111MODULE=on go build -ldflags="-s -w \
+	    -X $(VERSION_PKG).buildDate=$$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
+		-X $(VERSION_PKG).gitCommit=$$(git rev-parse HEAD 2>/dev/null || echo unknown) \
+		-X $(VERSION_PKG).gitTreeState=$$git_tree_state \
+		-X $(VERSION_PKG).gitVersion=$$(git describe --tags --abbrev=0 || echo develop)" \
+		-a -o kubectl-sigstore ./cmd/kubectl-sigstore

--- a/cmd/kubectl-sigstore/main.go
+++ b/cmd/kubectl-sigstore/main.go
@@ -50,6 +50,7 @@ func init() {
 	rootCmd.AddCommand(NewCmdVerifyResource())
 	rootCmd.AddCommand(NewCmdApplyAfterVerify())
 	rootCmd.AddCommand(NewCmdManifestBuild())
+	rootCmd.AddCommand(NewCmdVersion())
 
 	kubectlOptions.ConfigFlags.AddFlags(rootCmd.PersistentFlags())
 

--- a/cmd/kubectl-sigstore/version.go
+++ b/cmd/kubectl-sigstore/version.go
@@ -1,11 +1,11 @@
 //
-// Copyright 2020 IBM Corporation
+// Copyright 2021 The Sigstore Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/kubectl-sigstore/version.go
+++ b/cmd/kubectl-sigstore/version.go
@@ -1,0 +1,55 @@
+//
+// Copyright 2020 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+
+	k8smnfutil "github.com/sigstore/k8s-manifest-sigstore/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdVersion() *cobra.Command {
+
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "A command to print version of kubectl sigstore",
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			err := version()
+			if err != nil {
+				log.Fatal(err.Error())
+			}
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func version() error {
+	info := k8smnfutil.GetVersionInfo()
+	infoBytes, err := json.Marshal(info)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(infoBytes))
+	return nil
+}

--- a/example/admission-controller/config/common/configmap.yaml
+++ b/example/admission-controller/config/common/configmap.yaml
@@ -20,7 +20,7 @@ data:
 
     # only a signer with this name is allowed (in case of keyless)
     signers:
-    - sample-signer@gmail.com
+    - sample-signer@example.com
 
     # in case of key-ed signing, uncomment the following lines and comment out the `signers` condition
     # keySecretName: sample-key-secret

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -13,4 +13,4 @@ ignoreFields:
 
 # only a signer with this name is allowed (in case of keyless)
 signers:
-- sample-signer@gmail.com
+- sample-signer@example.com

--- a/pkg/util/version.go
+++ b/pkg/util/version.go
@@ -1,0 +1,74 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package util
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+var (
+	gitVersion   = "develop" // major and minor version are obtained by parsing this (e.g. v1.2.3 -> major: 1, minor: 2)
+	gitCommit    = "unknown"
+	gitTreeState = "unknown"
+	buildDate    = "unknown" // Build date in ISO8601 format by doing $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+)
+
+type VersionInfo struct {
+	Major        string `json:"Major"`
+	Minor        string `json:"Minor"`
+	GitVersion   string `json:"GitVersion"`
+	GitCommit    string `json:"GitCommit"`
+	GitTreeState string `json:"GitTreeState"`
+	BuildDate    string `json:"BuildDate"`
+	GoVersion    string `json:"GoVersion"`
+	Compiler     string `json:"Compiler"`
+	Platform     string `json:"Platform"`
+}
+
+func GetVersionInfo() *VersionInfo {
+	gitMajor, gitMinor := parseGitVersion(gitVersion)
+	return &VersionInfo{
+		Major:        gitMajor,
+		Minor:        gitMinor,
+		GitVersion:   gitVersion,
+		GitCommit:    gitCommit,
+		GitTreeState: gitTreeState,
+		BuildDate:    buildDate,
+		GoVersion:    runtime.Version(),
+		Compiler:     runtime.Compiler,
+		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}
+
+func parseGitVersion(gv string) (string, string) {
+	major := ""
+	minor := ""
+	if !strings.HasPrefix(gv, "v") {
+		return major, minor
+	}
+	tmp := strings.TrimPrefix(gv, "v")
+	parts := strings.Split(tmp, ".")
+	if len(parts) == 1 {
+		major = parts[0]
+	} else if len(parts) >= 2 {
+		major = parts[0]
+		minor = parts[1]
+	}
+	return major, minor
+}


### PR DESCRIPTION
Signed-off-by: Hirokuni-Kitahara1 hirokuni.kitahara1@ibm.com

- add `version` command which can show consistent results with `cosign version` / `kubectl version`

Example
```
$ kubectl sigstore version
{"Major":"","Minor":"","GitVersion":"develop","GitCommit":"6a68624364450d015ee1abc75fb5647a8d7b18d4","GitTreeState":"dirty","BuildDate":"2021-09-07T06:49:43Z","GoVersion":"go1.16.2","Compiler":"gc","Platform":"darwin/amd64"}


# example output after setting tag for a commit
$ kubectl sigstore version
{"Major":"0","Minor":"1","GitVersion":"v0.1.0","GitCommit":"6a68624364450d015ee1abc75fb5647a8d7b18d4","GitTreeState":"dirty","BuildDate":"2021-09-07T06:49:43Z","GoVersion":"go1.16.2","Compiler":"gc","Platform":"darwin/amd64"}
```
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
