### PR TITLE
fix issue of signing a directory

### DIFF
--- a/pkg/util/image.go
+++ b/pkg/util/image.go
@@ -136,8 +136,8 @@ func GetYAMLsInArtifact(blob []byte) ([][]byte, error) {
 		switch header.Typeflag {
 		case tar.TypeDir:
 			fpath := filepath.Join(dir, header.Name)
-			if err := os.Mkdir(fpath, 0755); err != nil {
-				return nil, errors.Wrap(err, "os.Mkdir() failed while decompressing tar gz")
+			if err := os.MkdirAll(fpath, 0755); err != nil {
+				return nil, errors.Wrap(err, "os.MkdirAll() failed while decompressing tar gz")
 			}
 		case tar.TypeReg:
 			fpath := filepath.Join(dir, header.Name)


### PR DESCRIPTION
Signed-off-by: Hirokuni-Kitahara1 <hirokuni.kitahara1@ibm.com>

- an issue for signing a directory has been fixed

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

