### PR TITLE
fix issue in signing for concatenated YAML manifests

### DIFF
--- a/cmd/kubectl-sigstore/cli/sign.go
+++ b/cmd/kubectl-sigstore/cli/sign.go
@@ -74,9 +74,13 @@ func sign(inputDir, imageRef, keyPath, output string, applySignatureConfigMap, u
 		}
 	}
 
-	anntns, err := parseAnnotations(annotations)
-	if err != nil {
-		return err
+	var anntns map[string]interface{}
+	var err error
+	if len(annotations) > 0 {
+		anntns, err = parseAnnotations(annotations)
+		if err != nil {
+			return err
+		}
 	}
 
 	so := &k8smanifest.SignOption{

--- a/cmd/kubectl-sigstore/cli/testdata/sample-configmap-concat.yaml
+++ b/cmd/kubectl-sigstore/cli/testdata/sample-configmap-concat.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sample-cm
+data:
+  key1: val1
+  key4: val4
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sample-cm-2
+data:
+  key2: val2

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -20,11 +20,13 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -168,6 +170,9 @@ func TarGzDecompress(src io.Reader, dst string) error {
 		}
 		if err != nil {
 			return err
+		}
+		if strings.Contains(header.Name, "..") {
+			return fmt.Errorf("a file contains \"..\" in its path cannot be decompressed, but `%s` has been found", header.Name)
 		}
 
 		// add dst + re-format slashes according to system


### PR DESCRIPTION
Signed-off-by: Hirokuni-Kitahara1 <hirokuni.kitahara1@ibm.com>

- fix image annotation option handling
- support concatenated YAML manifest when image annotation enabled
- add test case for signing concatenated YAML
- fix tar gz decompress util function
