### PR TITLE
support public key in a kubernetes secret for all signature types

### DIFF
--- a/cmd/kubectl-sigstore/cli/sign.go
+++ b/cmd/kubectl-sigstore/cli/sign.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/sigstore/k8s-manifest-sigstore/pkg/k8smanifest"
 	k8smnfutil "github.com/sigstore/k8s-manifest-sigstore/pkg/util"
+	kubeutil "github.com/sigstore/k8s-manifest-sigstore/pkg/util/kubeutil"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -91,7 +92,7 @@ func sign(inputDir, imageRef, keyPath, output string, applySignatureConfigMap, u
 		ImageAnnotations: anntns,
 	}
 
-	if applySignatureConfigMap && strings.HasPrefix(output, k8smanifest.InClusterObjectPrefix) {
+	if applySignatureConfigMap && strings.HasPrefix(output, kubeutil.InClusterObjectPrefix) {
 		so.ApplySigConfigMap = true
 	}
 
@@ -101,7 +102,7 @@ func sign(inputDir, imageRef, keyPath, output string, applySignatureConfigMap, u
 	}
 	if so.UpdateAnnotation {
 		finalOutput := output
-		if strings.HasPrefix(output, k8smanifest.InClusterObjectPrefix) && !applySignatureConfigMap {
+		if strings.HasPrefix(output, kubeutil.InClusterObjectPrefix) && !applySignatureConfigMap {
 			finalOutput = k8smanifest.K8sResourceRef2FileName(output)
 		}
 		log.Info("signed manifest generated at ", finalOutput)

--- a/cmd/kubectl-sigstore/cli/verify_resource.go
+++ b/cmd/kubectl-sigstore/cli/verify_resource.go
@@ -177,7 +177,7 @@ func verifyResource(yamls [][]byte, kubeGetArgs []string, imageRef, sigResRef, k
 		vo = &k8smanifest.VerifyResourceOption{}
 	} else if configPath == "" {
 		vo = k8smanifest.LoadDefaultConfig()
-	} else if strings.HasPrefix(configPath, k8smanifest.InClusterObjectPrefix) {
+	} else if strings.HasPrefix(configPath, kubeutil.InClusterObjectPrefix) {
 		vo, err = k8smanifest.LoadVerifyResourceConfigFromResource(configPath, configField)
 		if err != nil {
 			return false, errors.Wrapf(err, "failed to load verify-resource config from resource %s", configPath)
@@ -1166,9 +1166,9 @@ func getConfigPathFromConfigFlags(path, ctype, kind, name, namespace, field stri
 	}
 	newPath := ""
 	if namespace == "" {
-		newPath = fmt.Sprintf("%s%s/%s", k8smanifest.InClusterObjectPrefix, kind, name)
+		newPath = fmt.Sprintf("%s%s/%s", kubeutil.InClusterObjectPrefix, kind, name)
 	} else {
-		newPath = fmt.Sprintf("%s%s/%s/%s", k8smanifest.InClusterObjectPrefix, kind, namespace, name)
+		newPath = fmt.Sprintf("%s%s/%s/%s", kubeutil.InClusterObjectPrefix, kind, namespace, name)
 	}
 	if field == "" {
 		if ctype == configTypeConstraint {
@@ -1196,10 +1196,10 @@ func validateConfigMapRef(cmRefString string) string {
 	validatedParts := []string{}
 	for _, p := range parts {
 		var validP string
-		if strings.HasPrefix(p, k8smanifest.InClusterObjectPrefix) {
+		if strings.HasPrefix(p, kubeutil.InClusterObjectPrefix) {
 			validP = p
 		} else {
-			validP = fmt.Sprintf("%s%s/%s/%s", k8smanifest.InClusterObjectPrefix, "ConfigMap", defaultManifetBundleNamespace, p)
+			validP = fmt.Sprintf("%s%s/%s/%s", kubeutil.InClusterObjectPrefix, "ConfigMap", defaultManifetBundleNamespace, p)
 		}
 		validatedParts = append(validatedParts, validP)
 	}

--- a/pkg/k8smanifest/provenance.go
+++ b/pkg/k8smanifest/provenance.go
@@ -98,7 +98,7 @@ type ProvenanceGetter interface {
 
 func NewProvenanceGetter(obj *unstructured.Unstructured, sigRef, imageHash, provResRef string) ProvenanceGetter {
 	var imageRef string
-	if !strings.HasPrefix(sigRef, InClusterObjectPrefix) {
+	if !strings.HasPrefix(sigRef, kubeutil.InClusterObjectPrefix) {
 		imageRef = sigRef
 	}
 
@@ -667,7 +667,7 @@ func GenerateIntotoAttestationCurlCommand(logIndex int) string {
 }
 
 func GenerateIntotoAttestationKubectlCommand(resourceRef string) string {
-	kind, ns, name, _ := parseObjectInCluster(resourceRef)
+	kind, ns, name, _ := kubeutil.ParseObjectRefInClusterWithKind(resourceRef)
 	cmdStr := fmt.Sprintf("kubectl get %s -n %s %s -o=jsonpath='{.data.%s}'", kind, ns, name, AttestationDataKeyName)
 	return cmdStr
 }
@@ -678,7 +678,7 @@ func GenerateSBOMDownloadCommand(imageRef string) string {
 }
 
 func GenerateSBOMKubectlCommand(resourceRef string) string {
-	kind, ns, name, _ := parseObjectInCluster(resourceRef)
+	kind, ns, name, _ := kubeutil.ParseObjectRefInClusterWithKind(resourceRef)
 	cmdStr := fmt.Sprintf("kubectl get %s -n %s %s -o=jsonpath='{.data.%s}'", kind, ns, name, SBOMDataKeyName)
 	return cmdStr
 }

--- a/pkg/k8smanifest/sign.go
+++ b/pkg/k8smanifest/sign.go
@@ -82,7 +82,7 @@ func NewSigner(imageRef, keyPath, certPath, output string, doApply bool, Annotat
 		certPathP = &certPath
 	}
 	createSigConfigMap := false
-	if strings.HasPrefix(output, InClusterObjectPrefix) {
+	if strings.HasPrefix(output, kubeutil.InClusterObjectPrefix) {
 		createSigConfigMap = true
 	}
 	if imageRef != "" {
@@ -238,7 +238,7 @@ func uploadFileToRegistry(inputData []byte, imageRef string) error {
 }
 
 func generateSignatureConfigMap(sigResRef string, sigMaps map[string][]byte) (*corev1.ConfigMap, error) {
-	kind, ns, name, err := parseObjectInCluster(sigResRef)
+	kind, ns, name, err := kubeutil.ParseObjectRefInClusterWithKind(sigResRef)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to parse a signature configmap reference `%s`", sigResRef)
 	}
@@ -386,5 +386,5 @@ func applySignatureConfigMap(configMapRef string, newCM *corev1.ConfigMap) ([]by
 // sanitize resrouce ref as a filename
 // e.g.) k8s://ConfigMap/sample-ns/sample-cm --> k8s_ConfigMap_sample-ns_sample-cm.yaml
 func K8sResourceRef2FileName(resRef string) string {
-	return strings.ReplaceAll(strings.ReplaceAll(resRef, InClusterObjectPrefix, "k8s/"), "/", "_") + ".yaml"
+	return strings.ReplaceAll(strings.ReplaceAll(resRef, kubeutil.InClusterObjectPrefix, "k8s/"), "/", "_") + ".yaml"
 }

--- a/pkg/k8smanifest/verify.go
+++ b/pkg/k8smanifest/verify.go
@@ -42,7 +42,7 @@ type SignatureVerifier interface {
 
 func NewSignatureVerifier(objYAMLBytes []byte, sigRef string, pubkeyPath *string, annotationConfig AnnotationConfig) SignatureVerifier {
 	var imageRef, resourceRef string
-	if strings.HasPrefix(sigRef, InClusterObjectPrefix) {
+	if strings.HasPrefix(sigRef, kubeutil.InClusterObjectPrefix) {
 		resourceRef = sigRef
 	} else if sigRef != "" {
 		imageRef = sigRef
@@ -514,7 +514,7 @@ func (r *VerifyResult) String() string {
 }
 
 func GetConfigMapFromK8sObjectRef(objRef string) (*corev1.ConfigMap, error) {
-	kind, ns, name, err := parseObjectInCluster(objRef)
+	kind, ns, name, err := kubeutil.ParseObjectRefInClusterWithKind(objRef)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse a configmap reference")
 	}

--- a/pkg/util/sigtypes/sigtypes.go
+++ b/pkg/util/sigtypes/sigtypes.go
@@ -40,21 +40,21 @@ func GetSignatureTypeFromPublicKey(keyPathPtr *string) SigType {
 	}
 
 	// key-ed
-	keyPath := *keyPathPtr
+	keyRef := *keyPathPtr
 
 	// cosign public key
-	if _, err := cosignsig.PublicKeyFromKeyRef(context.Background(), keyPath); err == nil {
+	if _, err := cosignsig.PublicKeyFromKeyRef(context.Background(), keyRef); err == nil {
 		return SigTypeCosign
 	}
 
 	// pgp public key
-	_, err := pgp.LoadPublicKey(keyPath)
+	_, err := pgp.LoadPublicKey(keyRef)
 	if err == nil {
 		return SigTypePGP
 	}
 
 	// x509 ca cert
-	_, err = x509.LoadCertificate(keyPath)
+	_, err = x509.LoadCertificate(keyRef)
 	if err == nil {
 		return SigTypeX509
 	}


### PR DESCRIPTION
Signed-off-by: Hirokuni-Kitahara1 <hirokuni.kitahara1@ibm.com>

- support public key seceret in a k8s cluster for all signature types including gpg and x509. it will be able to specify the secret with `k8s://namespace/secretname`