### PR TITLE
support verification for multiple mutating webhooks

### DIFF
--- a/pkg/k8smanifest/option.go
+++ b/pkg/k8smanifest/option.go
@@ -58,9 +58,10 @@ type VerifyResourceOption struct {
 	verifyOption `json:""`
 	SkipObjects  ObjectReferenceList `json:"skipObjects,omitempty"`
 
-	Provenance          bool   `json:"-"`
-	CheckDryRunForApply bool   `json:"-"`
-	DryRunNamespace     string `json:"-"`
+	Provenance            bool   `json:"-"`
+	CheckDryRunForApply   bool   `json:"-"`
+	CheckMutatingResource bool   `json:"-"`
+	DryRunNamespace       string `json:"-"`
 }
 
 func (o *VerifyResourceOption) SetAnnotationIgnoreFields() {

--- a/pkg/k8smanifest/testdata/sample-configmap-signed-mutating-1.yaml
+++ b/pkg/k8smanifest/testdata/sample-configmap-signed-mutating-1.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+data:
+  key1: val1
+  key4: val4
+kind: ConfigMap
+metadata:
+  labels:
+    added-label-1: "test1"
+  annotations:
+    cosign.sigstore.dev/message: H4sIAAAAAAAA/wAlAdr+H4sIAAAAAAAA/+ySwU7zMBCEc85T+AXSrBMn+X+fkLggIW6Ia7UkjjGN16ntFrWId0dNKEfg0N7yXUYjzUo70gS046Cy1lFvtMUxC0aT6lYHtENyIQAAaiEmbepqUihmf4LXIuGC86ZqqgrKBMqmKOuEwaUe+IldiOgTgDvj3WZHZnVvIr6gR35jnu2qdXbOhYh9/0tJAPjWfI8+793QKR/yusu3hyNpS9Ss/0PVwrp9Bd4X27dTWFP+mLfOjl6FYEhnEX2mj/9KUYIoan7F+jiaJ+WDcSTZnqcdRpQpYxt14JLtceCzEZMR6cZQJ9nttJYHHFOrIp5vkMhFjMZRkOz9I2WM0CrJzhOzX9tKr1hnYWFhYeGPfAYAAP//vUESEwAIAAABAAD//wNsivclAQAA
+    cosign.sigstore.dev/signature: MEYCIQD3I/JwnOFc2TWpT2607Ziv8kxltlFn6rzSalnVq6J/1gIhAMAfnMh0YX37srS9MHmxG85TVaiLhqt2AvDihvPs7Ptt
+  creationTimestamp: "2022-03-22T02:20:13Z"
+  name: sample-cm-signed
+  namespace: test-ns
+  resourceVersion: "7246616"
+  uid: cbba7aa0-c377-4b56-a38a-a6b5614daedc

--- a/pkg/k8smanifest/testdata/sample-configmap-signed-mutating-2.yaml
+++ b/pkg/k8smanifest/testdata/sample-configmap-signed-mutating-2.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+data:
+  key1: val1
+  key4: val4
+kind: ConfigMap
+metadata:
+  labels:
+    added-label-1: "test1"
+    added-label-2: "test2"
+  annotations:
+    cosign.sigstore.dev/message: H4sIAAAAAAAA/wAlAdr+H4sIAAAAAAAA/+ySwU7zMBCEc85T+AXSrBMn+X+fkLggIW6Ia7UkjjGN16ntFrWId0dNKEfg0N7yXUYjzUo70gS046Cy1lFvtMUxC0aT6lYHtENyIQAAaiEmbepqUihmf4LXIuGC86ZqqgrKBMqmKOuEwaUe+IldiOgTgDvj3WZHZnVvIr6gR35jnu2qdXbOhYh9/0tJAPjWfI8+793QKR/yusu3hyNpS9Ss/0PVwrp9Bd4X27dTWFP+mLfOjl6FYEhnEX2mj/9KUYIoan7F+jiaJ+WDcSTZnqcdRpQpYxt14JLtceCzEZMR6cZQJ9nttJYHHFOrIp5vkMhFjMZRkOz9I2WM0CrJzhOzX9tKr1hnYWFhYeGPfAYAAP//vUESEwAIAAABAAD//wNsivclAQAA
+    cosign.sigstore.dev/signature: MEYCIQD3I/JwnOFc2TWpT2607Ziv8kxltlFn6rzSalnVq6J/1gIhAMAfnMh0YX37srS9MHmxG85TVaiLhqt2AvDihvPs7Ptt
+  creationTimestamp: "2022-03-22T02:20:13Z"
+  name: sample-cm-signed
+  namespace: test-ns
+  resourceVersion: "7246616"
+  uid: cbba7aa0-c377-4b56-a38a-a6b5614daedc

--- a/pkg/k8smanifest/verify_test.go
+++ b/pkg/k8smanifest/verify_test.go
@@ -74,3 +74,56 @@ func TestVerifyResource(t *testing.T) {
 	resultBytes, _ := json.Marshal(result)
 	t.Logf("verify-resource result: %s", string(resultBytes))
 }
+
+func TestInclusionMatch(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "k8smanifest-verify-resource-test")
+	if err != nil {
+		t.Errorf("failed to create temp dir: %s", err.Error())
+		return
+	}
+	defer os.RemoveAll(tmpDir)
+
+	keyPath := filepath.Join(tmpDir, "testpub")
+	err = initSingleTestFile(b64EncodedTestPubkey, keyPath)
+	if err != nil {
+		t.Errorf("failed to init a public key file for test: %s", err.Error())
+		return
+	}
+
+	f1path := "testdata/sample-configmap-signed.yaml"
+	mnfBytes, err := ioutil.ReadFile(f1path)
+	if err != nil {
+		t.Errorf("failed to load a test resource file for manifest: %s", err.Error())
+		return
+	}
+
+	f2path := "testdata/sample-configmap-signed-mutating-1.yaml"
+	objYAMLBytes, err := ioutil.ReadFile(f2path)
+	if err != nil {
+		t.Errorf("failed to load a test resource file for obejct: %s", err.Error())
+		return
+	}
+	objBytes, err := yaml.YAMLToJSON(objYAMLBytes)
+	if err != nil {
+		t.Errorf("failed to convert YAML to JSON for object: %s", err.Error())
+		return
+	}
+
+	f3path := "testdata/sample-configmap-signed-mutating-2.yaml"
+	dyrRunBytes, err := ioutil.ReadFile(f3path)
+	if err != nil {
+		t.Errorf("failed to load a test resource file for DryRun result: %s", err.Error())
+		return
+	}
+
+	verified, diff, err := inclusionMatch(mnfBytes, objBytes, dyrRunBytes, false, false)
+	if err != nil {
+		t.Errorf("failed to check inclusionMatch: %s", err.Error())
+		return
+	}
+	if !verified && diff != nil {
+		t.Errorf("diff found in inclusionMatch: %s", diff.String())
+		return
+	}
+	t.Log("inclusionMatch successfully finished.")
+}


### PR DESCRIPTION
Signed-off-by: Hirokuni-Kitahara1 <hirokuni.kitahara1@ibm.com>

- add `inclusionMatch` function for supporting verification in mutating admission controller
  - users can enable this verification by calling `VerifyResource()` with an option `VerifyMutatingResource = true`