### PR TITLE
support public key from environment variable as cosign does

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ Flags:
   -c, --config string     path to verification config YAML file (for advanced verification)
   -f, --filename string   file name which will be verified
   -h, --help              help for verify
-  -i, --image string      signed image name which bundles yaml files
-  -k, --key string        path to your signing key (if empty, do key-less signing)
+  -i, --image string      a comma-separated list of signed image names that contains YAML manifests
+  -k, --key string        a comma-separated list of paths to public keys or environment variable names start with "env://" (if empty, do key-less verification)
 ```
 
 ```
@@ -109,8 +109,8 @@ Flags:
   -c, --config string                  path to verification config YAML file (for advanced verification)
   -f, --filename string                file name which will be verified and applied
   -h, --help                           help for apply-after-verify
-  -i, --image string                   signed image name which bundles yaml files
-  -k, --key string                     path to your signing key (if empty, do key-less signing)
+  -i, --image string                   a comma-separated list of signed image names that contains YAML manifests
+  -k, --key string                     a comma-separated list of paths to public keys or environment variable names start with "env://" (if empty, do key-less verification)
 ```
 
 ```
@@ -123,7 +123,7 @@ Flags:
   -f, --filename string          manifest filename (this can be "-", then read a file from stdin)
   -h, --help                     help for verify-resource
   -i, --image string             a comma-separated list of signed image names that contains YAML manifests
-  -k, --key string               a comma-separated list of paths to public keys (if empty, do key-less verification)
+  -k, --key string               a comma-separated list of paths to public keys or environment variable names start with "env://" (if empty, do key-less verification)
   -o, --output string            output format string, either "json" or "yaml" (if empty, a result is shown as a table)
 ```
 

--- a/cmd/kubectl-sigstore/cli/apply_after_verify.go
+++ b/cmd/kubectl-sigstore/cli/apply_after_verify.go
@@ -57,8 +57,8 @@ func NewCmdApplyAfterVerify() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringVarP(&filename, "filename", "f", "", "file name which will be verified and applied")
-	cmd.PersistentFlags().StringVarP(&imageRef, "image", "i", "", "signed image name which bundles yaml files")
-	cmd.PersistentFlags().StringVarP(&keyPath, "key", "k", "", "path to your signing key (if empty, do key-less signing)")
+	cmd.PersistentFlags().StringVarP(&imageRef, "image", "i", "", "a comma-separated list of signed image names that contains YAML manifests")
+	cmd.PersistentFlags().StringVarP(&keyPath, "key", "k", "", "a comma-separated list of paths to public keys or environment variable names start with \"env://\" (if empty, do key-less verification)")
 	cmd.PersistentFlags().StringVarP(&configPath, "config", "c", "", "path to verification config YAML file (for advanced verification)")
 
 	KOptions.ConfigFlags.AddFlags(cmd.PersistentFlags())

--- a/cmd/kubectl-sigstore/cli/verify.go
+++ b/cmd/kubectl-sigstore/cli/verify.go
@@ -50,8 +50,8 @@ func NewCmdVerify() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringVarP(&filename, "filename", "f", "", "file name which will be verified")
-	cmd.PersistentFlags().StringVarP(&imageRef, "image", "i", "", "signed image name which bundles yaml files")
-	cmd.PersistentFlags().StringVarP(&keyPath, "key", "k", "", "path to your signing key (if empty, do key-less signing)")
+	cmd.PersistentFlags().StringVarP(&imageRef, "image", "i", "", "a comma-separated list of signed image names that contains YAML manifests")
+	cmd.PersistentFlags().StringVarP(&keyPath, "key", "k", "", "a comma-separated list of paths to public keys or environment variable names start with \"env://\" (if empty, do key-less verification)")
 	cmd.PersistentFlags().StringVarP(&configPath, "config", "c", "", "path to verification config YAML file (for advanced verification)")
 
 	return cmd

--- a/cmd/kubectl-sigstore/cli/verify_resource.go
+++ b/cmd/kubectl-sigstore/cli/verify_resource.go
@@ -145,7 +145,7 @@ func NewCmdVerifyResource() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&filename, "filename", "f", "", "manifest filename (this can be \"-\", then read a file from stdin)")
 	cmd.PersistentFlags().StringVarP(&imageRef, "image", "i", "", "a comma-separated list of signed image names that contains YAML manifests")
 	cmd.PersistentFlags().StringVar(&sigResRef, "signature-resource", "", "a comma-separated list of configmaps that contains message, signature and some others")
-	cmd.PersistentFlags().StringVarP(&keyPath, "key", "k", "", "a comma-separated list of paths to public keys (if empty, do key-less verification)")
+	cmd.PersistentFlags().StringVarP(&keyPath, "key", "k", "", "a comma-separated list of paths to public keys or environment variable names start with \"env://\" (if empty, do key-less verification)")
 	cmd.PersistentFlags().StringVarP(&configPath, "config", "c", "", "path to verification config YAML file or k8s object identifier like k8s://[KIND]/[NAMESPACE]/[NAME]")
 	cmd.PersistentFlags().StringVar(&configType, "config-type", "file", "a type of config, one of the following: \"file\", \"constraint\" or \"configmap\"")
 	cmd.PersistentFlags().StringVar(&configKind, "config-kind", "", "a kind of config resource in a cluster, only valid when --config-type is \"constraint\" or \"configmap\"")

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -32,6 +32,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const EnvVarFileRefPrefix = "env://"
+
 // AnnotationWriter represents the embedAnnotation function
 type AnnotationWriter func([]byte, map[string]interface{}) ([]byte, error)
 
@@ -287,4 +289,13 @@ func GetHomeDir() string {
 		dir = "/root"
 	}
 	return dir
+}
+
+func LoadFileDataInEnvVar(envVarRef string) ([]byte, error) {
+	envVarName := strings.TrimPrefix(envVarRef, EnvVarFileRefPrefix)
+	dataStr, found := os.LookupEnv(envVarName)
+	if !found {
+		return nil, fmt.Errorf("`$%s` is not found in environment variables", envVarName)
+	}
+	return []byte(dataStr), nil
 }

--- a/pkg/util/sigtypes/pgp/pgp.go
+++ b/pkg/util/sigtypes/pgp/pgp.go
@@ -129,6 +129,12 @@ func getPublicKeyStream(keyRef string) (io.Reader, error) {
 				break
 			}
 		}
+	} else if strings.HasPrefix(keyRef, k8smnfutil.EnvVarFileRefPrefix) {
+		keyBytes, err := k8smnfutil.LoadFileDataInEnvVar(keyRef)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to load the key in env var")
+		}
+		keyRingReader = bytes.NewBuffer(keyBytes)
 	} else {
 		kpath := filepath.Clean(keyRef)
 		keyRingReader, err = os.Open(kpath)

--- a/pkg/util/sigtypes/x509/x509.go
+++ b/pkg/util/sigtypes/x509/x509.go
@@ -123,6 +123,12 @@ func LoadCertificate(certPath string) (*x509.Certificate, error) {
 				certPemBytes = val
 			}
 		}
+	} else if strings.HasPrefix(certPath, k8smnfutil.EnvVarFileRefPrefix) {
+		tmpCertBytes, err := k8smnfutil.LoadFileDataInEnvVar(certPath)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to load the key in env var")
+		}
+		certPemBytes = tmpCertBytes
 	} else {
 		cpath := filepath.Clean(certPath)
 		certPemBytes, err = ioutil.ReadFile(cpath)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -207,6 +207,28 @@ var _ = Describe("E2e Test for Kubectl Sigstore Commands", func() {
 			return nil
 		}, timeout, 1).Should(BeNil())
 	})
+	It("VerifyResource Test with pubkey in env var", func() {
+		var timeout int = 10
+		Eventually(func() error {
+			testNamespace := "default"
+			testPubkeyBytes, err := base64.StdEncoding.DecodeString(string(b64EncodedTestPubKey))
+			if err != nil {
+				return err
+			}
+			pubkeyEnvVarName := "K8S_MANIFEST_SIGSTORE_TEST_PUBLIC_KEY"
+			err = os.Setenv(pubkeyEnvVarName, string(testPubkeyBytes))
+			if err != nil {
+				return err
+			}
+			defer os.Unsetenv(pubkeyEnvVarName)
+			pubkeyRef := fmt.Sprintf("env://%s", pubkeyEnvVarName)
+			err = verifyResource(outPath, pubkeyRef, testNamespace, "")
+			if err != nil {
+				return err
+			}
+			return nil
+		}, timeout, 1).Should(BeNil())
+	})
 	It("VerifyResource Test With Keyless-signed Resource", func() {
 		var timeout int = 10
 		Eventually(func() error {


### PR DESCRIPTION
Signed-off-by: Hirokuni-Kitahara1 <hirokuni.kitahara1@ibm.com>

- support public key from environment variable which starts with `env://`. this is the same way as cosign.
- add a test case with public key from env var
- update help texts that are shown when `--help` option is used