### PR TITLE
support multiple signatures for verification

### DIFF
--- a/docs/LATEST_RELEASE.md
+++ b/docs/LATEST_RELEASE.md
@@ -46,6 +46,23 @@ $ cd example/verify-resource
 $ go run sample.go
 ```
 
+## Support multiple signatures for verification
+
+We newly support multiple signatures for verification. In addition to the default signature, you can specify the other ones by using `AnnotationConfig` configuration both from CLI and from codes.
+
+An example of AnnotationConfig for this is like the following. In this case, 2 annotations `cosign.sigstore.dev/signature` (default one) and `cosign2.sigstore.dev/signature-alt` (added by this config) will be used. 
+
+```
+vo := &VerifyResourceOption{}
+vo.AnnotationConfig = AnnotationConfig{
+    AdditionalSignatureKeysForVerify: []string{
+        "cosign2.sigstore.dev/signature-alt",
+    },
+}
+```
+
+When multiple signatures are specified, verification will be ok if at least 1 signature is successfully verified.
+
 ## Add some options for a custom "verify-resource"
 
 The following 2 options are added as verify-resource options to enable flexible verification configuration.

--- a/pkg/k8smanifest/sign.go
+++ b/pkg/k8smanifest/sign.go
@@ -46,11 +46,11 @@ import (
 const DefaultAnnotationKeyDomain = "cosign.sigstore.dev"
 
 const (
-	ImageRefAnnotationBaseName    = "imageRef"
-	SignatureAnnotationBaseName   = "signature"
-	CertificateAnnotationBaseName = "certificate"
-	MessageAnnotationBaseName     = "message"
-	BundleAnnotationBaseName      = "bundle"
+	defaultImageRefAnnotationBaseName    = "imageRef"
+	defaultSignatureAnnotationBaseName   = "signature"
+	defaultCertificateAnnotationBaseName = "certificate"
+	defaultMessageAnnotationBaseName     = "message"
+	defaultBundleAnnotationBaseName      = "bundle"
 )
 
 func Sign(inputDir string, so *SignOption) ([]byte, error) {

--- a/pkg/k8smanifest/testdata/sample-configmap-multi-signed.yaml
+++ b/pkg/k8smanifest/testdata/sample-configmap-multi-signed.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+data:
+  key1: val1
+  key4: val4
+kind: ConfigMap
+metadata:
+  annotations:
+    # the first signature was signed by different key, so verification fails. the second one (signature-alt) should pass the verification.
+    cosign.sigstore.dev/message: H4sIAAAAAAAA/wAMAfP+H4sIAAAAAAAA/+zRQU/DIBQHcM79FHyBjUcH1PVk4sXEeDNel2dLK7ZAB6ym+/RmrfO4o8akv8s/fwIkL4+NGFjj+1qHyFTNjtPZtda54rAHWcGh+gDe5MdPAIDWsRdWeTsEHaNx7SZh2LRnAXd7JVVRAItoh15vKu8a01octhPanlzeKiHmLJScE/KlX/DdjnCRS5BS5ZIT2CkuBKFAfsEpJgwE4NEE352c2T6ZhO8YkN+bN7utvF3uxYRNc+Of71l+8p/AwbzqEI13JR151hlXl/Rh3t8zDpnVCWtMWGaUOrS6pNcV2+x63umJl3TEni9FzEVkfz3aarVarW74CgAA//9twMOhAAgAAAEAAP//LuzpogwBAAA=
+    cosign.sigstore.dev/signature: MEYCIQCDHyo+TlvuLDHav7TYLkW5MpvUguJ89I9rZVL7LgxSKAIhAIF3eRCj7+lIlGVvsH42xEFEKj14e2nEBrkTrQsD3AEf
+    cosign2.sigstore.dev/signature-alt: MEQCIG/x/yNDBWF/t5GafauG89/ohvUhCnONjkK8bRUj/dZdAiAbL1E33JQYNRVjcloi9xr6XeqNzf+Ya/VJ8bcNfVa3fA==
+  name: sample-cm

--- a/pkg/k8smanifest/verify_manifest.go
+++ b/pkg/k8smanifest/verify_manifest.go
@@ -42,7 +42,7 @@ func VerifyManifest(objManifest []byte, vo *VerifyManifestOption) (*VerifyResult
 	// if imageRef is not specified in args and it is found in object annotations, use the found image ref
 	var imageRefAnnotationKey string
 	if vo == nil {
-		imageRefAnnotationKey = fmt.Sprintf("%s/%s", DefaultAnnotationKeyDomain, ImageRefAnnotationBaseName)
+		imageRefAnnotationKey = fmt.Sprintf("%s/%s", DefaultAnnotationKeyDomain, defaultImageRefAnnotationBaseName)
 	} else {
 		imageRefAnnotationKey = vo.AnnotationConfig.ImageRefAnnotationKey()
 	}

--- a/pkg/k8smanifest/verify_resource.go
+++ b/pkg/k8smanifest/verify_resource.go
@@ -72,7 +72,7 @@ func VerifyResource(obj unstructured.Unstructured, vo *VerifyResourceOption) (*V
 	// if imageRef is not specified in args and it is found in object annotations, use the found image ref
 	var imageRefAnnotationKey string
 	if vo == nil {
-		imageRefAnnotationKey = fmt.Sprintf("%s/%s", DefaultAnnotationKeyDomain, ImageRefAnnotationBaseName)
+		imageRefAnnotationKey = fmt.Sprintf("%s/%s", DefaultAnnotationKeyDomain, defaultImageRefAnnotationBaseName)
 	} else {
 		imageRefAnnotationKey = vo.AnnotationConfig.ImageRefAnnotationKey()
 	}


### PR DESCRIPTION
Signed-off-by: Hirokuni-Kitahara1 <hirokuni.kitahara1@ibm.com>

- support multiple signatures by using AnnotationConfig
- add a test case for multiple signature verification
- update AnnotationConfig to make the annotation name configurable  (e.g. use `msg` instead of `message`)
- update release note