### PR TITLE
fix compression codes so that it can generate consistent message for the identical input

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/ProtonMail/go-crypto v0.0.0-20210707164159-52430bf6b52c
 	github.com/cyberphone/json-canonicalization v0.0.0-20210823021906-dc406ceaf94b
+	github.com/djherbis/times v1.5.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-openapi/runtime v0.23.3
 	github.com/google/go-containerregistry v0.8.1-0.20220209165246-a44adc326839

--- a/go.sum
+++ b/go.sum
@@ -733,6 +733,8 @@ github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi/U=
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
+github.com/djherbis/times v1.5.0 h1:79myA211VwPhFTqUk8xehWrsEO+zcIZj0zT8mXPVARU=
+github.com/djherbis/times v1.5.0/go.mod h1:5q7FDLvbNg1L/KaBmPcWlVR9NmoKo3+ucqUA3ijQhA0=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v20.10.2+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -28,9 +28,8 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"syscall"
-	"time"
 
+	filetimes "github.com/djherbis/times"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -285,10 +284,11 @@ func copyFile(src string, dst string) error {
 	}
 
 	// set the original timestamp metadata to generate consistent compression results everytime
-	mtime := fi.ModTime()
-	stat := fi.Sys().(*syscall.Stat_t)
-	atime := time.Unix(int64(stat.Atimespec.Sec), int64(stat.Atimespec.Nsec))
-	err = os.Chtimes(dst, atime, mtime)
+	tStat, err := filetimes.Stat(src)
+	if err != nil {
+		return err
+	}
+	err = os.Chtimes(dst, tStat.AccessTime(), tStat.ModTime())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Hirokuni-Kitahara1 <hirokuni.kitahara1@ibm.com>

- fix compression codes so that it can generate consistent message when the same YAML manifest is signed multiple times
- add test case for checking the message consistency