### PR TITLE
support multiple signatures both for signing and verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Flags:
   -k, --key string                  path to your signing key (if empty, do key-less signing)
   -o, --output string               output file name or k8s signature configmap reference (if empty, use "<filename>.signed")
       --replace-signature           just to clarify the default mode of signature storing. If false, "append-signature" is enabled automatically (default true)
+      --tarball string              whether to make a tarball for signing (this will be default to "no" in v0.5.0+) (default "yes")
 ```
 
 ```

--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ Flags:
   -a, --annotation stringArray      extra key=value pairs to sign
       --annotation-metadata         whether to update annotation and generate signed yaml file (default true)
   -A, --append-signature            if true, keep the existing signatures and append the new one to the annotation like "signature_1" or "signature_2"
-      --apply-signature-configmap   whether to apply a generated signature configmap only when "output" is k8s configmap
   -f, --filename string             file name which will be signed (if dir, all YAMLs inside it will be signed)
   -h, --help                        help for sign
   -i, --image string                image name which bundles yaml files and be signed

--- a/README.md
+++ b/README.md
@@ -80,13 +80,16 @@ Usage:
   kubectl sigstore sign -f FILENAME [-i IMAGE] [flags]
 
 Flags:
-  -a, --annotation stringArray     extra key=value pairs to sign
-      --annotation-metadata        whether to update annotation and generate signed yaml file (default true)
-  -f, --filename string            file name which will be signed (if dir, all YAMLs inside it will be signed)
-  -h, --help                       help for sign
-  -i, --image string               image name which bundles yaml files and be signed
-  -k, --key string                 path to your signing key (if empty, do key-less signing)
-  -o, --output <filename>.signed   output file name (if empty, use <filename>.signed)
+  -a, --annotation stringArray      extra key=value pairs to sign
+      --annotation-metadata         whether to update annotation and generate signed yaml file (default true)
+  -A, --append-signature            if true, keep the existing signatures and append the new one to the annotation like "signature_1" or "signature_2"
+      --apply-signature-configmap   whether to apply a generated signature configmap only when "output" is k8s configmap
+  -f, --filename string             file name which will be signed (if dir, all YAMLs inside it will be signed)
+  -h, --help                        help for sign
+  -i, --image string                image name which bundles yaml files and be signed
+  -k, --key string                  path to your signing key (if empty, do key-less signing)
+  -o, --output string               output file name or k8s signature configmap reference (if empty, use "<filename>.signed")
+      --replace-signature           just to clarify the default mode of signature storing. If false, "append-signature" is enabled automatically (default true)
 ```
 
 ```

--- a/cmd/kubectl-sigstore/cli/apply_after_verify.go
+++ b/cmd/kubectl-sigstore/cli/apply_after_verify.go
@@ -90,9 +90,8 @@ func applyAfterVerify(filename, imageRef, keyPath, configPath string) error {
 	vo.SetAnnotationIgnoreFields()
 
 	annotations := k8ssigutil.GetAnnotationsInYAML(manifest)
-	imageRefAnnotationKey := vo.AnnotationConfig.ImageRefAnnotationKey()
-	annoImageRef, annoImageRefFound := annotations[imageRefAnnotationKey]
-	if imageRef == "" && annoImageRefFound {
+	resBundleRefAnnotationKey := vo.AnnotationConfig.ResourceBundleRefAnnotationKey()
+	if annoImageRef, annoImageRefFound := annotations[resBundleRefAnnotationKey]; annoImageRefFound {
 		imageRef = annoImageRef
 	}
 	log.Debug("annotations", annotations)

--- a/cmd/kubectl-sigstore/cli/apply_after_verify.go
+++ b/cmd/kubectl-sigstore/cli/apply_after_verify.go
@@ -35,7 +35,7 @@ import (
 
 func NewCmdApplyAfterVerify() *cobra.Command {
 
-	var imageRef string
+	var resBundleRef string
 	var filename string
 	var keyPath string
 	var configPath string
@@ -48,7 +48,7 @@ func NewCmdApplyAfterVerify() *cobra.Command {
 			if err != nil {
 				return errors.Wrap(err, "failed to initialize a configuration for kubectl apply command")
 			}
-			err = applyAfterVerify(filename, imageRef, keyPath, configPath)
+			err = applyAfterVerify(filename, resBundleRef, keyPath, configPath)
 			if err != nil {
 				return err
 			}
@@ -57,7 +57,7 @@ func NewCmdApplyAfterVerify() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringVarP(&filename, "filename", "f", "", "file name which will be verified and applied")
-	cmd.PersistentFlags().StringVarP(&imageRef, "image", "i", "", "a comma-separated list of signed image names that contains YAML manifests")
+	cmd.PersistentFlags().StringVarP(&resBundleRef, "image", "i", "", "a comma-separated list of signed image names that contains YAML manifests")
 	cmd.PersistentFlags().StringVarP(&keyPath, "key", "k", "", "a comma-separated list of paths to public keys or environment variable names start with \"env://\" (if empty, do key-less verification)")
 	cmd.PersistentFlags().StringVarP(&configPath, "config", "c", "", "path to verification config YAML file (for advanced verification)")
 
@@ -71,7 +71,7 @@ func NewCmdApplyAfterVerify() *cobra.Command {
 	return cmd
 }
 
-func applyAfterVerify(filename, imageRef, keyPath, configPath string) error {
+func applyAfterVerify(filename, resBundleRef, keyPath, configPath string) error {
 	manifest, err := ioutil.ReadFile(filename)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
@@ -91,14 +91,14 @@ func applyAfterVerify(filename, imageRef, keyPath, configPath string) error {
 
 	annotations := k8ssigutil.GetAnnotationsInYAML(manifest)
 	resBundleRefAnnotationKey := vo.AnnotationConfig.ResourceBundleRefAnnotationKey()
-	if annoImageRef, annoImageRefFound := annotations[resBundleRefAnnotationKey]; annoImageRefFound {
-		imageRef = annoImageRef
+	if annoResBundleRef, annoResBundleRefFound := annotations[resBundleRefAnnotationKey]; annoResBundleRefFound {
+		resBundleRef = annoResBundleRef
 	}
 	log.Debug("annotations", annotations)
-	log.Debug("imageRef", imageRef)
+	log.Debug("resourceBundleRef", resBundleRef)
 
-	if imageRef != "" {
-		vo.ImageRef = imageRef
+	if resBundleRef != "" {
+		vo.ResourceBundleRef = resBundleRef
 	}
 	if keyPath != "" {
 		vo.KeyPath = keyPath

--- a/cmd/kubectl-sigstore/cli/manifest_build.go
+++ b/cmd/kubectl-sigstore/cli/manifest_build.go
@@ -36,7 +36,7 @@ var supportedMode = []string{
 func NewCmdManifestBuild() *cobra.Command {
 
 	var baseDir string
-	var imageRef string
+	var resBundleRef string
 	var keyPath string
 	var outputPath string
 	var provenancePath string
@@ -47,7 +47,7 @@ func NewCmdManifestBuild() *cobra.Command {
 		Short: "A command to build a Kubernetes YAML manifest with provenance",
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			err := buildManifest(baseDir, outputPath, provenancePath, imageRef, keyPath, kustomizeMode, signProvenance)
+			err := buildManifest(baseDir, outputPath, provenancePath, resBundleRef, keyPath, kustomizeMode, signProvenance)
 			if err != nil {
 				return err
 			}
@@ -60,12 +60,12 @@ func NewCmdManifestBuild() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&baseDir, "dir", "d", "", "kustomize base dir")
 	cmd.PersistentFlags().StringVarP(&outputPath, "output", "o", "", "path to output manifest file")
 	cmd.PersistentFlags().StringVarP(&provenancePath, "provenance", "p", "", "path to output provenance file")
-	cmd.PersistentFlags().StringVarP(&imageRef, "image", "i", "", "image reference in which a generated manifest is stored")
+	cmd.PersistentFlags().StringVarP(&resBundleRef, "image", "i", "", "image reference in which a generated manifest is stored")
 	cmd.PersistentFlags().StringVarP(&keyPath, "key", "k", "", "path to your signing key")
 	return cmd
 }
 
-func buildManifest(baseDir, outputPath, provenancePath, imageRef, keyPath string, kustomizeMode, signProvenance bool) error {
+func buildManifest(baseDir, outputPath, provenancePath, resBundleRef, keyPath string, kustomizeMode, signProvenance bool) error {
 
 	if !kustomizeMode {
 		return fmt.Errorf("only the following manifest types are supported: %v", supportedMode)
@@ -87,7 +87,7 @@ func buildManifest(baseDir, outputPath, provenancePath, imageRef, keyPath string
 		return errors.Wrap(err, "failed to create a manifest file")
 	}
 	// TODO: support uploading manifest image
-	// if imageRef != "" {
+	// if resBundleRef != "" {
 	//
 	// }
 	digest, err := kustbuildutil.GetDigestOfArtifact(manifestFile)

--- a/cmd/kubectl-sigstore/cli/sign.go
+++ b/cmd/kubectl-sigstore/cli/sign.go
@@ -52,11 +52,6 @@ func NewCmdSign() *cobra.Command {
 
 			makeTarball := (tarballOpt == "yes")
 
-			// tarball causes inconsistent message among multiple signing, so disable it if append mode
-			if appendSignature {
-				makeTarball = false
-			}
-
 			err := sign(inputDir, imageRef, keyPath, output, appendSignature, applySignatureConfigMap, updateAnnotation, makeTarball, imageAnnotations)
 			if err != nil {
 				log.Fatalf("error occurred during signing: %s", err.Error())

--- a/cmd/kubectl-sigstore/cli/sign.go
+++ b/cmd/kubectl-sigstore/cli/sign.go
@@ -37,6 +37,7 @@ func NewCmdSign() *cobra.Command {
 	var keyPath string
 	var output string
 	var appendSignature bool
+	var replaceSignature bool
 	var applySignatureConfigMap bool
 	var updateAnnotation bool
 	var tarballOpt string
@@ -45,6 +46,9 @@ func NewCmdSign() *cobra.Command {
 		Use:   "sign -f FILENAME [-i IMAGE]",
 		Short: "A command to sign Kubernetes YAML manifests",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if !replaceSignature {
+				appendSignature = true
+			}
 
 			makeTarball := (tarballOpt == "yes")
 			err := sign(inputDir, imageRef, keyPath, output, appendSignature, applySignatureConfigMap, updateAnnotation, makeTarball, imageAnnotations)
@@ -58,10 +62,11 @@ func NewCmdSign() *cobra.Command {
 
 	cmd.PersistentFlags().StringVarP(&inputDir, "filename", "f", "", "file name which will be signed (if dir, all YAMLs inside it will be signed)")
 	cmd.PersistentFlags().StringVarP(&imageRef, "image", "i", "", "image name which bundles yaml files and be signed")
-	cmd.PersistentFlags().StringVarP(&output, "output", "o", "", "output file name or k8s signature configmap reference (if empty, use `<filename>.signed`)")
+	cmd.PersistentFlags().StringVarP(&output, "output", "o", "", "output file name or k8s signature configmap reference (if empty, use \"<filename>.signed\")")
 	cmd.PersistentFlags().StringVarP(&keyPath, "key", "k", "", "path to your signing key (if empty, do key-less signing)")
-	cmd.PersistentFlags().BoolVar(&appendSignature, "append-signature", false, "if true, keep the existing signatures and append the new one to the annotation like `signature_1` or `signature_2`")
-	cmd.PersistentFlags().BoolVar(&applySignatureConfigMap, "apply-signature-configmap", false, "whether to apply a generated signature configmap only when `output` is k8s configmap")
+	cmd.PersistentFlags().BoolVarP(&appendSignature, "append-signature", "A", false, "if true, keep the existing signatures and append the new one to the annotation like \"signature_1\" or \"signature_2\"")
+	cmd.PersistentFlags().BoolVar(&replaceSignature, "replace-signature", true, "just to clarify the default mode of signature storing. If false, \"append-signature\" is enabled automatically")
+	cmd.PersistentFlags().BoolVar(&applySignatureConfigMap, "apply-signature-configmap", false, "whether to apply a generated signature configmap only when \"output\" is k8s configmap")
 	cmd.PersistentFlags().BoolVar(&updateAnnotation, "annotation-metadata", true, "whether to update annotation and generate signed yaml file")
 	cmd.PersistentFlags().StringVar(&tarballOpt, "tarball", "yes", "whether to make a tarball for signing (this will be default to \"no\" in v0.5.0+)")
 	cmd.PersistentFlags().StringArrayVarP(&imageAnnotations, "annotation", "a", []string{}, "extra key=value pairs to sign")

--- a/cmd/kubectl-sigstore/cli/sign.go
+++ b/cmd/kubectl-sigstore/cli/sign.go
@@ -32,7 +32,7 @@ const filenameIfInputIsDir = "manifest.yaml"
 
 func NewCmdSign() *cobra.Command {
 
-	var imageRef string
+	var resBundleRef string
 	var inputDir string
 	var keyPath string
 	var output string
@@ -52,7 +52,7 @@ func NewCmdSign() *cobra.Command {
 
 			makeTarball := (tarballOpt == "yes")
 
-			err := sign(inputDir, imageRef, keyPath, output, appendSignature, applySignatureConfigMap, updateAnnotation, makeTarball, imageAnnotations)
+			err := sign(inputDir, resBundleRef, keyPath, output, appendSignature, applySignatureConfigMap, updateAnnotation, makeTarball, imageAnnotations)
 			if err != nil {
 				log.Fatalf("error occurred during signing: %s", err.Error())
 				return nil
@@ -62,7 +62,7 @@ func NewCmdSign() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringVarP(&inputDir, "filename", "f", "", "file name which will be signed (if dir, all YAMLs inside it will be signed)")
-	cmd.PersistentFlags().StringVarP(&imageRef, "image", "i", "", "image name which bundles yaml files and be signed")
+	cmd.PersistentFlags().StringVarP(&resBundleRef, "image", "i", "", "image name which bundles yaml files and be signed")
 	cmd.PersistentFlags().StringVarP(&output, "output", "o", "", "output file name or k8s signature configmap reference (if empty, use \"<filename>.signed\")")
 	cmd.PersistentFlags().StringVarP(&keyPath, "key", "k", "", "path to your signing key (if empty, do key-less signing)")
 	cmd.PersistentFlags().BoolVarP(&appendSignature, "append-signature", "A", false, "if true, keep the existing signatures and append the new one to the annotation like \"signature_1\" or \"signature_2\"")
@@ -75,7 +75,7 @@ func NewCmdSign() *cobra.Command {
 	return cmd
 }
 
-func sign(inputDir, imageRef, keyPath, output string, appendSignature, applySignatureConfigMap, updateAnnotation, tarball bool, annotations []string) error {
+func sign(inputDir, resBundleRef, keyPath, output string, appendSignature, applySignatureConfigMap, updateAnnotation, tarball bool, annotations []string) error {
 	if output == "" && updateAnnotation {
 		if isDir, _ := k8smnfutil.IsDir(inputDir); isDir {
 			// e.g.) "./yamls/" --> "./yamls/manifest.yaml.signed"
@@ -96,13 +96,13 @@ func sign(inputDir, imageRef, keyPath, output string, appendSignature, applySign
 	}
 
 	so := &k8smanifest.SignOption{
-		ImageRef:         imageRef,
-		KeyPath:          keyPath,
-		Output:           output,
-		UpdateAnnotation: updateAnnotation,
-		Tarball:          &tarball,
-		ImageAnnotations: anntns,
-		AppendSignature:  appendSignature,
+		ResourceBundleRef: resBundleRef,
+		KeyPath:           keyPath,
+		Output:            output,
+		UpdateAnnotation:  updateAnnotation,
+		Tarball:           &tarball,
+		ImageAnnotations:  anntns,
+		AppendSignature:   appendSignature,
 	}
 
 	if applySignatureConfigMap && strings.HasPrefix(output, kubeutil.InClusterObjectPrefix) {

--- a/cmd/kubectl-sigstore/cli/sign.go
+++ b/cmd/kubectl-sigstore/cli/sign.go
@@ -51,6 +51,12 @@ func NewCmdSign() *cobra.Command {
 			}
 
 			makeTarball := (tarballOpt == "yes")
+
+			// tarball causes inconsistent message among multiple signing, so disable it if append mode
+			if appendSignature {
+				makeTarball = false
+			}
+
 			err := sign(inputDir, imageRef, keyPath, output, appendSignature, applySignatureConfigMap, updateAnnotation, makeTarball, imageAnnotations)
 			if err != nil {
 				log.Fatalf("error occurred during signing: %s", err.Error())

--- a/cmd/kubectl-sigstore/cli/verify.go
+++ b/cmd/kubectl-sigstore/cli/verify.go
@@ -32,7 +32,7 @@ import (
 
 func NewCmdVerify() *cobra.Command {
 
-	var imageRef string
+	var resBundleRef string
 	var filename string
 	var keyPath string
 	var configPath string
@@ -41,7 +41,7 @@ func NewCmdVerify() *cobra.Command {
 		Short: "A command to verify Kubernetes YAML manifests",
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			err := verify(filename, imageRef, keyPath, configPath)
+			err := verify(filename, resBundleRef, keyPath, configPath)
 			if err != nil {
 				return err
 			}
@@ -50,14 +50,14 @@ func NewCmdVerify() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringVarP(&filename, "filename", "f", "", "file name which will be verified")
-	cmd.PersistentFlags().StringVarP(&imageRef, "image", "i", "", "a comma-separated list of signed image names that contains YAML manifests")
+	cmd.PersistentFlags().StringVarP(&resBundleRef, "image", "i", "", "a comma-separated list of signed image names that contains YAML manifests")
 	cmd.PersistentFlags().StringVarP(&keyPath, "key", "k", "", "a comma-separated list of paths to public keys or environment variable names start with \"env://\" (if empty, do key-less verification)")
 	cmd.PersistentFlags().StringVarP(&configPath, "config", "c", "", "path to verification config YAML file (for advanced verification)")
 
 	return cmd
 }
 
-func verify(filename, imageRef, keyPath, configPath string) error {
+func verify(filename, resBundleRef, keyPath, configPath string) error {
 	manifest, err := ioutil.ReadFile(filename)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
@@ -77,14 +77,14 @@ func verify(filename, imageRef, keyPath, configPath string) error {
 
 	annotations := k8ssigutil.GetAnnotationsInYAML(manifest)
 	resBundleRefAnnotationKey := vo.AnnotationConfig.ResourceBundleRefAnnotationKey()
-	if annoImageRef, annoImageRefFound := annotations[resBundleRefAnnotationKey]; annoImageRefFound {
-		imageRef = annoImageRef
+	if annoResBundleRef, annoResBundleRefFound := annotations[resBundleRefAnnotationKey]; annoResBundleRefFound {
+		resBundleRef = annoResBundleRef
 	}
 	log.Debug("annotations", annotations)
-	log.Debug("imageRef", imageRef)
+	log.Debug("resourceBundleRef", resBundleRef)
 
-	if imageRef != "" {
-		vo.ImageRef = imageRef
+	if resBundleRef != "" {
+		vo.ResourceBundleRef = resBundleRef
 	}
 	if keyPath != "" {
 		vo.KeyPath = keyPath

--- a/cmd/kubectl-sigstore/cli/verify.go
+++ b/cmd/kubectl-sigstore/cli/verify.go
@@ -76,9 +76,8 @@ func verify(filename, imageRef, keyPath, configPath string) error {
 	vo.SetAnnotationIgnoreFields()
 
 	annotations := k8ssigutil.GetAnnotationsInYAML(manifest)
-	imageRefAnnotationKey := vo.AnnotationConfig.ImageRefAnnotationKey()
-	annoImageRef, annoImageRefFound := annotations[imageRefAnnotationKey]
-	if imageRef == "" && annoImageRefFound {
+	resBundleRefAnnotationKey := vo.AnnotationConfig.ResourceBundleRefAnnotationKey()
+	if annoImageRef, annoImageRefFound := annotations[resBundleRefAnnotationKey]; annoImageRefFound {
 		imageRef = annoImageRef
 	}
 	log.Debug("annotations", annotations)

--- a/cmd/kubectl-sigstore/cli/verify_resource.go
+++ b/cmd/kubectl-sigstore/cli/verify_resource.go
@@ -1215,10 +1215,10 @@ type imageToBeUsed struct {
 func getAllImagesToBeUsed(imageRef string, objs []unstructured.Unstructured, annotationConfig k8smanifest.AnnotationConfig, provenanceEnabled bool) []imageToBeUsed {
 	images := []imageToBeUsed{}
 	if imageRef == "" {
-		imageAnnotationKey := annotationConfig.ImageRefAnnotationKey()
+		resBundleRefAnnotationKey := annotationConfig.ResourceBundleRefAnnotationKey()
 		for _, obj := range objs {
 			annt := obj.GetAnnotations()
-			if img, ok := annt[imageAnnotationKey]; ok {
+			if img, ok := annt[resBundleRefAnnotationKey]; ok {
 				images = append(images, imageToBeUsed{imageType: k8smanifest.ArtifactManifestImage, ImageObject: kubeutil.ImageObject{ImageRef: img}})
 			}
 		}

--- a/cmd/kubectl-sigstore/cli/verify_resource.go
+++ b/cmd/kubectl-sigstore/cli/verify_resource.go
@@ -85,7 +85,7 @@ var OSExit = os.Exit
 func NewCmdVerifyResource() *cobra.Command {
 
 	var filename string
-	var imageRef string
+	var resBundleRef string
 	var sigResRef string
 	var keyPath string
 	var configPath string
@@ -131,7 +131,7 @@ func NewCmdVerifyResource() *cobra.Command {
 				provResRef = manifestBundleResRef
 			}
 
-			allVerified, err := verifyResource(manifestYAMLs, kubeGetArgs, imageRef, sigResRef, keyPath, configPath, configField, configType, disableDefaultConfig, provenance, provResRef, outputFormat, concurrencyNum)
+			allVerified, err := verifyResource(manifestYAMLs, kubeGetArgs, resBundleRef, sigResRef, keyPath, configPath, configField, configType, disableDefaultConfig, provenance, provResRef, outputFormat, concurrencyNum)
 			if err != nil {
 				log.Fatalf("error occurred during verify-resource: %s", err.Error())
 			}
@@ -143,7 +143,7 @@ func NewCmdVerifyResource() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringVarP(&filename, "filename", "f", "", "manifest filename (this can be \"-\", then read a file from stdin)")
-	cmd.PersistentFlags().StringVarP(&imageRef, "image", "i", "", "a comma-separated list of signed image names that contains YAML manifests")
+	cmd.PersistentFlags().StringVarP(&resBundleRef, "image", "i", "", "a comma-separated list of signed image names that contains YAML manifests")
 	cmd.PersistentFlags().StringVar(&sigResRef, "signature-resource", "", "a comma-separated list of configmaps that contains message, signature and some others")
 	cmd.PersistentFlags().StringVarP(&keyPath, "key", "k", "", "a comma-separated list of paths to public keys or environment variable names start with \"env://\" (if empty, do key-less verification)")
 	cmd.PersistentFlags().StringVarP(&configPath, "config", "c", "", "path to verification config YAML file or k8s object identifier like k8s://[KIND]/[NAMESPACE]/[NAME]")
@@ -163,7 +163,7 @@ func NewCmdVerifyResource() *cobra.Command {
 	return cmd
 }
 
-func verifyResource(yamls [][]byte, kubeGetArgs []string, imageRef, sigResRef, keyPath, configPath, configField, configType string, disableDefaultConfig, provenance bool, provResRef, outputFormat string, concurrencyNum int64) (bool, error) {
+func verifyResource(yamls [][]byte, kubeGetArgs []string, resBundleRef, sigResRef, keyPath, configPath, configField, configType string, disableDefaultConfig, provenance bool, provResRef, outputFormat string, concurrencyNum int64) (bool, error) {
 	var err error
 	start := time.Now().UTC()
 	if outputFormat != "" {
@@ -207,8 +207,8 @@ func verifyResource(yamls [][]byte, kubeGetArgs []string, imageRef, sigResRef, k
 		objs, err = KOptions.Get(kubeGetArgs, "")
 	} else if yamls != nil {
 		objs, err = getObjsFromManifests(yamls, vo.IgnoreFields)
-	} else if imageRef != "" {
-		manifestFetcher := k8smanifest.NewManifestFetcher(imageRef, "", vo.AnnotationConfig, nil, vo.MaxResourceManifestNum)
+	} else if resBundleRef != "" {
+		manifestFetcher := k8smanifest.NewManifestFetcher(resBundleRef, "", vo.AnnotationConfig, nil, vo.MaxResourceManifestNum)
 		imageManifestFetcher := manifestFetcher.(*k8smanifest.ImageManifestFetcher)
 		var yamlsInImage [][]byte
 		if yamlsInImage, err = imageManifestFetcher.FetchAll(); err == nil {
@@ -219,8 +219,8 @@ func verifyResource(yamls [][]byte, kubeGetArgs []string, imageRef, sigResRef, k
 		return false, errors.Wrap(err, "failed to get objects in cluster")
 	}
 
-	if imageRef != "" {
-		vo.ImageRef = imageRef
+	if resBundleRef != "" {
+		vo.ResourceBundleRef = resBundleRef
 	}
 	if sigResRef != "" {
 		vo.SignatureResourceRef = validateConfigMapRef(sigResRef)
@@ -235,7 +235,7 @@ func verifyResource(yamls [][]byte, kubeGetArgs []string, imageRef, sigResRef, k
 		vo.ProvenanceResourceRef = validateConfigMapRef(provResRef)
 	}
 
-	imagesToBeused := getAllImagesToBeUsed(vo.ImageRef, objs, vo.AnnotationConfig, vo.Provenance)
+	imagesToBeused := getAllImagesToBeUsed(vo.ResourceBundleRef, objs, vo.AnnotationConfig, vo.Provenance)
 
 	if outputFormat == "" {
 		log.Info("loading some required data.")
@@ -246,7 +246,7 @@ func verifyResource(yamls [][]byte, kubeGetArgs []string, imageRef, sigResRef, k
 		img := imagesToBeused[i]
 		// manifest fetch functions
 		if img.imageType == k8smanifest.ArtifactManifestImage {
-			manifestFetcher := k8smanifest.NewManifestFetcher(img.ImageRef, "", vo.AnnotationConfig, nil, 0)
+			manifestFetcher := k8smanifest.NewManifestFetcher(img.ResourceBundleRef, "", vo.AnnotationConfig, nil, 0)
 			if fetcher, ok := manifestFetcher.(*k8smanifest.ImageManifestFetcher); ok {
 				prepareFuncs = append(prepareFuncs, reflect.ValueOf(fetcher.FetchAll))
 			}
@@ -257,14 +257,14 @@ func verifyResource(yamls [][]byte, kubeGetArgs []string, imageRef, sigResRef, k
 			keyPath = &(vo.KeyPath)
 		}
 		// signature verification functions
-		sigVerifier := k8smanifest.NewSignatureVerifier(nil, img.ImageRef, keyPath, vo.AnnotationConfig)
+		sigVerifier := k8smanifest.NewSignatureVerifier(nil, img.ResourceBundleRef, keyPath, vo.AnnotationConfig)
 		if verifier, ok := sigVerifier.(*k8smanifest.ImageSignatureVerifier); ok {
 			prepareFuncs = append(prepareFuncs, reflect.ValueOf(verifier.Verify))
 		}
 
 		if vo.Provenance {
 			// provenance functions
-			provGetter := k8smanifest.NewProvenanceGetter(nil, img.ImageRef, img.Digest, "")
+			provGetter := k8smanifest.NewProvenanceGetter(nil, img.ResourceBundleRef, img.Digest, "")
 			if getter, ok := provGetter.(*k8smanifest.ImageProvenanceGetter); ok {
 				prepareFuncs = append(prepareFuncs, reflect.ValueOf(getter.Get))
 			}
@@ -851,7 +851,7 @@ func makeResourceResultTable(result VerifyResourceResult, provenanceEnabled bool
 				attestationFoundStr := "-"
 				sbomFoundStr := "-"
 				for _, prov := range result.Provenance.Items {
-					if prov.Artifact != ci.ImageRef {
+					if prov.Artifact != ci.ResourceBundleRef {
 						continue
 					}
 					if prov.RawAttestation != "" {
@@ -1212,20 +1212,20 @@ type imageToBeUsed struct {
 }
 
 // list all images to be used for manifest matching, signature verification and provenance search
-func getAllImagesToBeUsed(imageRef string, objs []unstructured.Unstructured, annotationConfig k8smanifest.AnnotationConfig, provenanceEnabled bool) []imageToBeUsed {
+func getAllImagesToBeUsed(resBundleRef string, objs []unstructured.Unstructured, annotationConfig k8smanifest.AnnotationConfig, provenanceEnabled bool) []imageToBeUsed {
 	images := []imageToBeUsed{}
-	if imageRef == "" {
+	if resBundleRef == "" {
 		resBundleRefAnnotationKey := annotationConfig.ResourceBundleRefAnnotationKey()
 		for _, obj := range objs {
 			annt := obj.GetAnnotations()
 			if img, ok := annt[resBundleRefAnnotationKey]; ok {
-				images = append(images, imageToBeUsed{imageType: k8smanifest.ArtifactManifestImage, ImageObject: kubeutil.ImageObject{ImageRef: img}})
+				images = append(images, imageToBeUsed{imageType: k8smanifest.ArtifactManifestImage, ImageObject: kubeutil.ImageObject{ResourceBundleRef: img}})
 			}
 		}
 	} else {
-		imageRefList := k8ssigutil.SplitCommaSeparatedString(imageRef)
-		for _, img := range imageRefList {
-			images = append(images, imageToBeUsed{imageType: k8smanifest.ArtifactManifestImage, ImageObject: kubeutil.ImageObject{ImageRef: img}})
+		resBundleRefList := k8ssigutil.SplitCommaSeparatedString(resBundleRef)
+		for _, img := range resBundleRefList {
+			images = append(images, imageToBeUsed{imageType: k8smanifest.ArtifactManifestImage, ImageObject: kubeutil.ImageObject{ResourceBundleRef: img}})
 		}
 	}
 

--- a/example/admission-controller/main.go
+++ b/example/admission-controller/main.go
@@ -99,14 +99,14 @@ func (h *k8sManifestHandler) Handle(ctx context.Context, req admission.Request) 
 		allow = true
 		message = "this resource is not in scope of verification"
 	} else {
-		imageRef := config.ImageRef
+		resBundleRef := config.ResourceBundleRef
 		keyPath := ""
 		if config.KeySecertName != "" {
 			keyPath, _ = config.LoadKeySecret()
 		}
 		vo := &(config.VerifyResourceOption)
-		if imageRef != "" {
-			vo.ImageRef = imageRef
+		if resBundleRef != "" {
+			vo.ResourceBundleRef = resBundleRef
 		}
 		if keyPath != "" {
 			vo.KeyPath = keyPath

--- a/example/admission-controller/pkg/config/config.go
+++ b/example/admission-controller/pkg/config/config.go
@@ -42,7 +42,7 @@ type ManifestIntegrityConfig struct {
 	SkipUsers                        ObjectUserBindingList           `json:"skipUsers,omitempty"`
 	KeySecertName                    string                          `json:"keySecretName,omitempty"`
 	KeySecertNamespace               string                          `json:"keySecretNamespace,omitempty"`
-	ImageRef                         string                          `json:"imageRef,omitempty"`
+	ResourceBundleRef                string                          `json:"resourceBundleRef,omitempty"`
 }
 
 type ObjectUserBindingList []ObjectUserBinding

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/ProtonMail/go-crypto v0.0.0-20210707164159-52430bf6b52c
 	github.com/cyberphone/json-canonicalization v0.0.0-20210823021906-dc406ceaf94b
+	github.com/djherbis/times v1.5.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-openapi/runtime v0.23.3
 	github.com/google/go-containerregistry v0.8.1-0.20220209165246-a44adc326839

--- a/go.sum
+++ b/go.sum
@@ -733,6 +733,8 @@ github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi/U=
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
+github.com/djherbis/times v1.5.0 h1:79myA211VwPhFTqUk8xehWrsEO+zcIZj0zT8mXPVARU=
+github.com/djherbis/times v1.5.0/go.mod h1:5q7FDLvbNg1L/KaBmPcWlVR9NmoKo3+ucqUA3ijQhA0=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v20.10.2+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=

--- a/pkg/cosign/sign.go
+++ b/pkg/cosign/sign.go
@@ -47,7 +47,7 @@ const (
 	defaultTlogUploadTimeout = 10
 )
 
-func SignImage(imageRef string, keyPath, certPath *string, pf cosign.PassFunc, imageAnnotations map[string]interface{}) error {
+func SignImage(resBundleRef string, keyPath, certPath *string, pf cosign.PassFunc, imageAnnotations map[string]interface{}) error {
 	// TODO: add support for sk (security key) and idToken (identity token for cert from fulcio)
 	sk := false
 	idToken := ""
@@ -84,7 +84,7 @@ func SignImage(imageRef string, keyPath, certPath *string, pf cosign.PassFunc, i
 	outputSignaturePath := ""
 	outputCertificatePath := ""
 
-	return clisign.SignCmd(rootOpt, opt, regOpt, imageAnnotations, []string{imageRef}, certPathStr, "", true, outputSignaturePath, outputCertificatePath, "", false, false, "")
+	return clisign.SignCmd(rootOpt, opt, regOpt, imageAnnotations, []string{resBundleRef}, certPathStr, "", true, outputSignaturePath, outputCertificatePath, "", false, false, "")
 }
 
 func SignBlob(blobPath string, keyPath, certPath *string, pf cosign.PassFunc) (map[string][]byte, error) {

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -45,10 +45,10 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature/payload"
 )
 
-func VerifyImage(imageRef string, pubkeyPath string) (bool, string, *int64, error) {
-	ref, err := name.ParseReference(imageRef)
+func VerifyImage(resBundleRef string, pubkeyPath string) (bool, string, *int64, error) {
+	ref, err := name.ParseReference(resBundleRef)
 	if err != nil {
-		return false, "", nil, fmt.Errorf("failed to parse image ref `%s`; %s", imageRef, err.Error())
+		return false, "", nil, fmt.Errorf("failed to parse image ref `%s`; %s", resBundleRef, err.Error())
 	}
 
 	rekorSeverURL := GetRekorServerURL()
@@ -85,10 +85,10 @@ func VerifyImage(imageRef string, pubkeyPath string) (bool, string, *int64, erro
 
 	checkedSigs, _, err := cosign.VerifyImageSignatures(context.Background(), ref, co)
 	if err != nil {
-		return false, "", nil, fmt.Errorf("error occured while verifying image `%s`; %s", imageRef, err.Error())
+		return false, "", nil, fmt.Errorf("error occured while verifying image `%s`; %s", resBundleRef, err.Error())
 	}
 	if len(checkedSigs) == 0 {
-		return false, "", nil, fmt.Errorf("no verified signatures in the image `%s`; %s", imageRef, err.Error())
+		return false, "", nil, fmt.Errorf("no verified signatures in the image `%s`; %s", resBundleRef, err.Error())
 	}
 	var cert *x509.Certificate
 	var signedTimestamp *int64

--- a/pkg/k8smanifest/opiton_test.go
+++ b/pkg/k8smanifest/opiton_test.go
@@ -49,9 +49,9 @@ data:
 		return
 	}
 
-	imageRefAnnotationKey := vo.AnnotationConfig.ImageRefAnnotationKey()
-	if imageRefAnnotationKey == "" {
-		t.Error("failed to get imageRefAnnotationKey; this config must not be empty and must return `cosign.sigstore.dev/iamgeRef` if empty")
+	resourceBundleRefAnnotationKey := vo.AnnotationConfig.ResourceBundleRefAnnotationKey()
+	if resourceBundleRefAnnotationKey == "" {
+		t.Error("failed to get imageRefAnnotationKey; this config must not be empty and must return `cosign.sigstore.dev/resourceBundleRef` if empty")
 		return
 	}
 }

--- a/pkg/k8smanifest/opiton_test.go
+++ b/pkg/k8smanifest/opiton_test.go
@@ -51,7 +51,7 @@ data:
 
 	resourceBundleRefAnnotationKey := vo.AnnotationConfig.ResourceBundleRefAnnotationKey()
 	if resourceBundleRefAnnotationKey == "" {
-		t.Error("failed to get imageRefAnnotationKey; this config must not be empty and must return `cosign.sigstore.dev/resourceBundleRef` if empty")
+		t.Error("failed to get resBundleRefAnnotationKey; this config must not be empty and must return `cosign.sigstore.dev/resourceBundleRef` if empty")
 		return
 	}
 }

--- a/pkg/k8smanifest/option.go
+++ b/pkg/k8smanifest/option.go
@@ -44,7 +44,7 @@ type SignOption struct {
 
 	// these options should be input from CLI arguments
 	KeyPath           string                 `json:"-"`
-	ImageRef          string                 `json:"-"`
+	ResourceBundleRef string                 `json:"-"`
 	CertPath          string                 `json:"-"`
 	Output            string                 `json:"-"`
 	UpdateAnnotation  bool                   `json:"-"`
@@ -99,7 +99,7 @@ type verifyOption struct {
 
 	// these options should be input from CLI arguments
 	KeyPath               string `json:"-"`
-	ImageRef              string `json:"-"`
+	ResourceBundleRef     string `json:"-"`
 	SignatureResourceRef  string `json:"-"`
 	ProvenanceResourceRef string `json:"-"`
 	UseCache              bool   `json:"-"`
@@ -424,14 +424,14 @@ func parseConfigObj(configObj *unstructured.Unstructured, configField string) (*
 		return nil, fmt.Errorf("failed to parse config field `%s` in `%s`", configField, configObj.GetName())
 	}
 	var configBytes []byte
-	var imageRefInConfigObj string
+	var resBundleRefInConfigObj string
 	switch cfg := cfgData.(type) {
 	case string:
 		configBytes = []byte(cfg)
 	case *mapnode.Node:
 		configBytes = []byte(cfg.ToYaml())
-		if tmpImageRef := cfg.GetString("imageRef"); tmpImageRef != "" {
-			imageRefInConfigObj = tmpImageRef
+		if tmpResourceBundleRef := cfg.GetString("resourceBundleRef"); tmpResourceBundleRef != "" {
+			resBundleRefInConfigObj = tmpResourceBundleRef
 		}
 	default:
 		return nil, fmt.Errorf("cannot handle this type for config object: %T", cfg)
@@ -442,8 +442,8 @@ func parseConfigObj(configObj *unstructured.Unstructured, configField string) (*
 	if err != nil {
 		return nil, err
 	}
-	if imageRefInConfigObj != "" {
-		option.ImageRef = imageRefInConfigObj
+	if resBundleRefInConfigObj != "" {
+		option.ResourceBundleRef = resBundleRefInConfigObj
 	}
 	return option, nil
 }

--- a/pkg/k8smanifest/option.go
+++ b/pkg/k8smanifest/option.go
@@ -18,6 +18,7 @@ package k8smanifest
 
 import (
 	_ "embed"
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -51,6 +52,7 @@ type SignOption struct {
 	PassFunc          cosign.PassFunc        `json:"-"`
 	ApplySigConfigMap bool                   `json:"-"`
 	Tarball           *bool                  `json:"-"`
+	AppendSignature   bool                   `json:"-"`
 }
 
 // option for VerifyResource()
@@ -126,74 +128,105 @@ type AnnotationConfig struct {
 	// default "cosign.sigstore.dev"
 	AnnotationKeyDomain string `json:"annotationKeyDomain,omitempty"`
 
-	ImageRefBaseName    string `json:"imageRefBaseName,omitempty"`
-	SignatureBaseName   string `json:"signatureBaseName,omitempty"`
-	CertificateBaseName string `json:"certificateBaseName,omitempty"`
-	MessageBaseName     string `json:"messageBaseName,omitempty"`
-	BundleBaseName      string `json:"bundleBaseName,omitempty"`
-
-	// signature annotation keys in addition to `<AnnotationKeyDomain>/signature`
-	// e.g.) annotation.domain.com/signature-alt
-	// this config is used only for verification
-	AdditionalSignatureKeysForVerify []string `json:"additionalSignatureKeysForVerify,omitempty"`
-}
-
-func (c AnnotationConfig) ImageRefAnnotationKey() string {
-	return c.annotationKey(firstNonEmpty(c.ImageRefBaseName, defaultImageRefAnnotationBaseName))
-}
-
-func (c AnnotationConfig) SignatureAnnotationKey() string {
-	return c.annotationKey(firstNonEmpty(c.SignatureBaseName, defaultSignatureAnnotationBaseName))
-}
-
-func (c AnnotationConfig) SignatureAnnotationKeysForVerify() []string {
-	keys := []string{c.SignatureAnnotationKey()}
-	keys = append(keys, c.AdditionalSignatureKeysForVerify...)
-	return keys
-}
-
-func (c AnnotationConfig) CertificateAnnotationKey() string {
-	return c.annotationKey(firstNonEmpty(c.CertificateBaseName, defaultCertificateAnnotationBaseName))
+	ResourceBundleRefBaseName string `json:"resourceBundleRefBaseName,omitempty"`
+	SignatureBaseName         string `json:"signatureBaseName,omitempty"`
+	CertificateBaseName       string `json:"certificateBaseName,omitempty"`
+	MessageBaseName           string `json:"messageBaseName,omitempty"`
+	BundleBaseName            string `json:"bundleBaseName,omitempty"`
 }
 
 func (c AnnotationConfig) MessageAnnotationKey() string {
-	return c.annotationKey(firstNonEmpty(c.MessageBaseName, defaultMessageAnnotationBaseName))
+	return c.annotationKey(firstNonEmpty(c.MessageBaseName, defaultMessageAnnotationBaseName), 0)
 }
 
-func (c AnnotationConfig) BundleAnnotationKey() string {
-	return c.annotationKey(firstNonEmpty(c.BundleBaseName, defaultBundleAnnotationBaseName))
+func (c AnnotationConfig) SignatureAnnotationKey(i int) string {
+	return c.annotationKey(firstNonEmpty(c.SignatureBaseName, defaultSignatureAnnotationBaseName), i)
 }
 
-func (c AnnotationConfig) annotationKey(keyType string) string {
+func (c AnnotationConfig) CertificateAnnotationKey(i int) string {
+	return c.annotationKey(firstNonEmpty(c.CertificateBaseName, defaultCertificateAnnotationBaseName), i)
+}
+
+func (c AnnotationConfig) BundleAnnotationKey(i int) string {
+	return c.annotationKey(firstNonEmpty(c.BundleBaseName, defaultBundleAnnotationBaseName), i)
+}
+
+func (c AnnotationConfig) ResourceBundleRefAnnotationKey() string {
+	return c.annotationKey(firstNonEmpty(c.ResourceBundleRefBaseName, defaultResourceBundleRefAnnotationBaseName), 0)
+}
+
+func (c AnnotationConfig) annotationKey(keyType string, i int) string {
 	d := c.AnnotationKeyDomain
 	if d == "" {
 		d = DefaultAnnotationKeyDomain
 	}
-	return fmt.Sprintf("%s/%s", d, keyType)
+	key := fmt.Sprintf("%s/%s", d, keyType)
+	if i > 0 {
+		key = fmt.Sprintf("%s_%v", key, i)
+	}
+	return key
 }
 
 // this map determins annotations in the signed manifest
-func (c AnnotationConfig) AnnotationKeyMap() map[string]string {
+func (c AnnotationConfig) AnnotationKeyMap(i int) map[string]string {
 	return map[string]string{
-		defaultImageRefAnnotationBaseName:    c.ImageRefAnnotationKey(),
-		defaultSignatureAnnotationBaseName:   c.SignatureAnnotationKey(),
-		defaultCertificateAnnotationBaseName: c.CertificateAnnotationKey(),
-		defaultMessageAnnotationBaseName:     c.MessageAnnotationKey(),
-		defaultBundleAnnotationBaseName:      c.BundleAnnotationKey(),
+		defaultMessageAnnotationBaseName:           c.MessageAnnotationKey(),
+		defaultSignatureAnnotationBaseName:         c.SignatureAnnotationKey(i),
+		defaultCertificateAnnotationBaseName:       c.CertificateAnnotationKey(i),
+		defaultBundleAnnotationBaseName:            c.BundleAnnotationKey(i),
+		defaultResourceBundleRefAnnotationBaseName: c.ResourceBundleRefAnnotationKey(),
 	}
+}
+
+func (c AnnotationConfig) GetAllSignatureSets(annotations map[string]string) []map[string]string {
+	sigSets := []map[string]string{}
+	msgKey := c.MessageAnnotationKey()
+	msg, ok := annotations[msgKey]
+	annotationBytes, _ := json.Marshal(annotations)
+	log.Debugf("annotations: %s", string(annotationBytes))
+	if !ok {
+		return []map[string]string{}
+	}
+	for i := 0; ; i++ {
+		sig, ok := annotations[c.SignatureAnnotationKey(i)]
+		// if signature_i is not found, finish looking for signature set
+		if !ok {
+			break
+		}
+		sigMapi := map[string]string{}
+		// message
+		sigMapi[defaultMessageAnnotationBaseName] = msg
+		// signature
+		sigMapi[defaultSignatureAnnotationBaseName] = sig
+		// certificate
+		if cert, ok := annotations[c.CertificateAnnotationKey(i)]; ok {
+			sigMapi[defaultCertificateAnnotationBaseName] = cert
+		}
+		// bundle
+		if bndl, ok := annotations[c.BundleAnnotationKey(i)]; ok {
+			sigMapi[defaultBundleAnnotationBaseName] = bndl
+		}
+		sigSets = append(sigSets, sigMapi)
+
+		// prevent from infinite loop; the num of signature sets is always less than the num of annotations
+		if i > len(annotations) {
+			break
+		}
+	}
+	sigSetsBytes, _ := json.Marshal(sigSets)
+	log.Debugf("sigSets: %s", string(sigSetsBytes))
+	return sigSets
 }
 
 // this list is used as ignorefields for verification
 func (c AnnotationConfig) AnnotationKeyMask() []string {
-	masks := []string{
-		"metadata.annotations." + c.ImageRefAnnotationKey(),
-		"metadata.annotations." + c.SignatureAnnotationKey(),
-		"metadata.annotations." + c.CertificateAnnotationKey(),
-		"metadata.annotations." + c.MessageAnnotationKey(),
-		"metadata.annotations." + c.BundleAnnotationKey(),
+	return []string{
+		"metadata.annotations." + c.MessageAnnotationKey() + "*",
+		"metadata.annotations." + c.SignatureAnnotationKey(0) + "*",
+		"metadata.annotations." + c.CertificateAnnotationKey(0) + "*",
+		"metadata.annotations." + c.BundleAnnotationKey(0) + "*",
+		"metadata.annotations." + c.ResourceBundleRefAnnotationKey() + "*",
 	}
-	masks = append(masks, c.AdditionalSignatureKeysForVerify...)
-	return masks
 }
 
 func (c AnnotationConfig) AnnotationKeyIgnoreField() ObjectFieldBindingList {

--- a/pkg/k8smanifest/resources/default-config.yaml
+++ b/pkg/k8smanifest/resources/default-config.yaml
@@ -1,6 +1,6 @@
 ignoreFields:
   - fields:
-    - metadata.annotations.cosign.sigstore.dev/imageRef
+    - metadata.annotations.cosign.sigstore.dev/resourceBundleRef
     - metadata.annotations.cosign.sigstore.dev/signature
     - metadata.annotations.cosign.sigstore.dev/message
     - metadata.annotations.cosign.sigstore.dev/certificate

--- a/pkg/k8smanifest/sign.go
+++ b/pkg/k8smanifest/sign.go
@@ -61,6 +61,12 @@ func Sign(inputDir string, so *SignOption) ([]byte, error) {
 		so.Tarball = &defaultTarballOption
 	}
 	makeTarball := *(so.Tarball)
+
+	// tarball causes inconsistent message among multiple signing, so disable it if append mode
+	if so.AppendSignature {
+		makeTarball = false
+	}
+
 	if makeTarball {
 		log.Warn("[DEPRECATED] The current signing method which makes a tarball for signing is deprecated in v0.3.1+, and will be unavailable in v0.5.0. You can use the new method by `--tarball=no` from CLI or `Tarball: &(false)` in SignOption from codes.")
 	}

--- a/pkg/k8smanifest/sign.go
+++ b/pkg/k8smanifest/sign.go
@@ -120,12 +120,12 @@ func (s *ImageSigner) Sign(inputDir, output string, imageAnnotations map[string]
 	}
 	var err error
 	if s.tarball {
-		err = k8ssigutil.TarGzCompress(inputDir, &inputDataBuffer, mo)
+		err = k8ssigutil.TarGzCompress(inputDir, &inputDataBuffer, moClean, moImage)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to compress an input file/dir")
 		}
 	} else {
-		err = makeMessageYAML(inputDir, &inputDataBuffer, mo)
+		err = makeMessageYAML(inputDir, &inputDataBuffer, moClean, moImage)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to make a message YAML from the input file/dir")
 		}
@@ -182,12 +182,12 @@ func (s *BlobSigner) Sign(inputDir, output string, imageAnnotations map[string]i
 	}
 
 	if s.tarball {
-		err = k8ssigutil.TarGzCompress(inputDir, &inputDataBuffer, mo)
+		err = k8ssigutil.TarGzCompress(inputDir, &inputDataBuffer, moClean, moImage)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to compress an input file/dir")
 		}
 	} else {
-		err = makeMessageYAML(inputDir, &inputDataBuffer, mo)
+		err = makeMessageYAML(inputDir, &inputDataBuffer, moClean, moImage)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to make a message YAML from the input file/dir")
 		}

--- a/pkg/k8smanifest/sign_test.go
+++ b/pkg/k8smanifest/sign_test.go
@@ -64,7 +64,7 @@ func TestSign(t *testing.T) {
 	}
 	t.Logf("signed YAML file: %s", string(signedBytes))
 
-	var obj1, obj2 unstructured.Unstructured
+	var obj1, obj2, obj3 unstructured.Unstructured
 	err = yaml.Unmarshal(signedBytes, &obj1)
 	if err != nil {
 		t.Errorf("failed to unmarshal the signed yaml: %s", err.Error())
@@ -89,6 +89,26 @@ func TestSign(t *testing.T) {
 	msg2 := annotationMap2[msgKey]
 	if msg1 != msg2 {
 		t.Errorf("the message is different from the first time even though the input is identical")
+		return
+	}
+
+	// then, try signing with "AppendSignature" option on the signed manifest
+	so.AppendSignature = true
+	thirdSignedBytes, err := Sign(outPath, so)
+	if err != nil {
+		t.Errorf("failed to sign the test file (3rd time): %s", err.Error())
+		return
+	}
+	err = yaml.Unmarshal(thirdSignedBytes, &obj3)
+	if err != nil {
+		t.Errorf("failed to unmarshal the signed yaml (3rd time): %s", err.Error())
+		return
+	}
+	annotationMap3 := obj3.GetAnnotations()
+	sigKey := DefaultAnnotationKeyDomain + "/signature_1"
+	_, ok := annotationMap3[sigKey]
+	if !ok {
+		t.Errorf("`%s` is not found in the signed yaml manifest after signing with AppendSignature option", sigKey)
 		return
 	}
 }

--- a/pkg/k8smanifest/sign_test.go
+++ b/pkg/k8smanifest/sign_test.go
@@ -22,6 +22,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/ghodss/yaml"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // files for test cases
@@ -60,6 +63,34 @@ func TestSign(t *testing.T) {
 		return
 	}
 	t.Logf("signed YAML file: %s", string(signedBytes))
+
+	var obj1, obj2 unstructured.Unstructured
+	err = yaml.Unmarshal(signedBytes, &obj1)
+	if err != nil {
+		t.Errorf("failed to unmarshal the signed yaml: %s", err.Error())
+		return
+	}
+	annotationMap := obj1.GetAnnotations()
+	msgKey := DefaultAnnotationKeyDomain + "/message"
+	msg1 := annotationMap[msgKey]
+
+	// 2nd time to check message consistency
+	secondSignedBytes, err := Sign(fpath, so)
+	if err != nil {
+		t.Errorf("failed to sign the test file (2nd time): %s", err.Error())
+		return
+	}
+	err = yaml.Unmarshal(secondSignedBytes, &obj2)
+	if err != nil {
+		t.Errorf("failed to unmarshal the signed yaml (2nd time): %s", err.Error())
+		return
+	}
+	annotationMap2 := obj2.GetAnnotations()
+	msg2 := annotationMap2[msgKey]
+	if msg1 != msg2 {
+		t.Errorf("the message is different from the first time even though the input is identical")
+		return
+	}
 }
 
 func TestNonTarballSign(t *testing.T) {

--- a/pkg/k8smanifest/testdata/sample-configmap-multi-signed.yaml
+++ b/pkg/k8smanifest/testdata/sample-configmap-multi-signed.yaml
@@ -5,8 +5,7 @@ data:
 kind: ConfigMap
 metadata:
   annotations:
-    # the first signature was signed by different key, so verification fails. the second one (signature-alt) should pass the verification.
-    cosign.sigstore.dev/message: H4sIAAAAAAAA/wAMAfP+H4sIAAAAAAAA/+zRQU/DIBQHcM79FHyBjUcH1PVk4sXEeDNel2dLK7ZAB6ym+/RmrfO4o8akv8s/fwIkL4+NGFjj+1qHyFTNjtPZtda54rAHWcGh+gDe5MdPAIDWsRdWeTsEHaNx7SZh2LRnAXd7JVVRAItoh15vKu8a01octhPanlzeKiHmLJScE/KlX/DdjnCRS5BS5ZIT2CkuBKFAfsEpJgwE4NEE352c2T6ZhO8YkN+bN7utvF3uxYRNc+Of71l+8p/AwbzqEI13JR151hlXl/Rh3t8zDpnVCWtMWGaUOrS6pNcV2+x63umJl3TEni9FzEVkfz3aarVarW74CgAA//9twMOhAAgAAAEAAP//LuzpogwBAAA=
-    cosign.sigstore.dev/signature: MEYCIQCDHyo+TlvuLDHav7TYLkW5MpvUguJ89I9rZVL7LgxSKAIhAIF3eRCj7+lIlGVvsH42xEFEKj14e2nEBrkTrQsD3AEf
-    cosign2.sigstore.dev/signature-alt: MEQCIG/x/yNDBWF/t5GafauG89/ohvUhCnONjkK8bRUj/dZdAiAbL1E33JQYNRVjcloi9xr6XeqNzf+Ya/VJ8bcNfVa3fA==
+    cosign.sigstore.dev/message: H4sIAAAAAAAA/0osyAxLLSrOzM+zUigz5EpJLEm04lJQyE6tNLRSKEvMMYRwTMAcE67szLwUKwXn/Ly0zHTfxAKu3NSSRJievMTcVCuF4sTcgpxU3eRcLkAAAAD//+afMJFbAAAA
+    cosign.sigstore.dev/signature: MEYCIQDE1VjyWuCulKugUo3PYxAZu9h3LnPXkKOkAAAiJMgzGwIhAMrVlCkvtwWT1czBgd5Bh/JiKC+25OWxE5LOG+PjTHX+
+    cosign.sigstore.dev/signature_1: MEYCIQCYwrnNuHI4yNyLK5TNI6gpp440YTvseUD2Gd5WTPYynQIhAMdZp2+c66Qiz+H1xpxwFZ7bgGnwkO8vZ0YfiVVjnuNh
   name: sample-cm

--- a/pkg/k8smanifest/verify.go
+++ b/pkg/k8smanifest/verify.go
@@ -41,18 +41,18 @@ type SignatureVerifier interface {
 }
 
 func NewSignatureVerifier(objYAMLBytes []byte, sigRef string, pubkeyPath *string, annotationConfig AnnotationConfig) SignatureVerifier {
-	var imageRef, resourceRef string
+	var resBundleRef, resourceRef string
 
 	resBundleRefAnnotationKey := annotationConfig.ResourceBundleRefAnnotationKey()
 	annotations := k8smnfutil.GetAnnotationsInYAML(objYAMLBytes)
-	if annoImageRef, ok := annotations[resBundleRefAnnotationKey]; ok {
-		imageRef = annoImageRef
+	if annoResBundleRef, ok := annotations[resBundleRefAnnotationKey]; ok {
+		resBundleRef = annoResBundleRef
 	}
 
 	if strings.HasPrefix(sigRef, kubeutil.InClusterObjectPrefix) {
 		resourceRef = sigRef
-	} else if sigRef != "" && imageRef == "" {
-		imageRef = sigRef
+	} else if sigRef != "" && resBundleRef == "" {
+		resBundleRef = sigRef
 	}
 
 	var pubkeyPathString *string
@@ -60,23 +60,23 @@ func NewSignatureVerifier(objYAMLBytes []byte, sigRef string, pubkeyPath *string
 		pubkeyPathString = pubkeyPath
 	}
 
-	if imageRef != "" && imageRef != SigRefEmbeddedInAnnotation {
-		return &ImageSignatureVerifier{imageRef: imageRef, onMemoryCacheEnabled: true, pubkeyPathString: pubkeyPathString, annotationConfig: annotationConfig}
+	if resBundleRef != "" && resBundleRef != SigRefEmbeddedInAnnotation {
+		return &ImageSignatureVerifier{resBundleRef: resBundleRef, onMemoryCacheEnabled: true, pubkeyPathString: pubkeyPathString, annotationConfig: annotationConfig}
 	} else {
 		return &BlobSignatureVerifier{annotations: annotations, resourceRef: resourceRef, pubkeyPathString: pubkeyPathString, annotationConfig: annotationConfig}
 	}
 }
 
 type ImageSignatureVerifier struct {
-	imageRef             string
+	resBundleRef         string
 	pubkeyPathString     *string
 	onMemoryCacheEnabled bool
 	annotationConfig     AnnotationConfig
 }
 
 func (v *ImageSignatureVerifier) Verify() (bool, string, *int64, error) {
-	imageRef := v.imageRef
-	if imageRef == "" {
+	resBundleRef := v.resBundleRef
+	if resBundleRef == "" {
 		return false, "", nil, errors.New("no image reference is found")
 	}
 
@@ -99,7 +99,7 @@ func (v *ImageSignatureVerifier) Verify() (bool, string, *int64, error) {
 		for i := range pubkeys {
 			pubkey := pubkeys[i]
 			// try getting result from cache
-			cacheFound, verified, signerName, signedTimestamp, err = v.getResultFromCache(imageRef, pubkey)
+			cacheFound, verified, signerName, signedTimestamp, err = v.getResultFromCache(resBundleRef, pubkey)
 			// if found and verified true, return it
 			if cacheFound {
 				cacheFoundCount += 1
@@ -121,11 +121,11 @@ func (v *ImageSignatureVerifier) Verify() (bool, string, *int64, error) {
 	for i := range pubkeys {
 		pubkey := pubkeys[i]
 		// do normal image verification
-		verified, signerName, signedTimestamp, err = k8smnfcosign.VerifyImage(imageRef, pubkey)
+		verified, signerName, signedTimestamp, err = k8smnfcosign.VerifyImage(resBundleRef, pubkey)
 
 		if v.onMemoryCacheEnabled {
 			// set the result to cache
-			v.setResultToCache(imageRef, pubkey, verified, signerName, signedTimestamp, err)
+			v.setResultToCache(resBundleRef, pubkey, verified, signerName, signedTimestamp, err)
 		}
 
 		if verified {
@@ -137,8 +137,8 @@ func (v *ImageSignatureVerifier) Verify() (bool, string, *int64, error) {
 	return false, "", nil, fmt.Errorf("signature verification failed: %s", strings.Join(allErrs, "; "))
 }
 
-func (v *ImageSignatureVerifier) getResultFromCache(imageRef, pubkey string) (bool, bool, string, *int64, error) {
-	key := fmt.Sprintf("cache/verify-image/%s/%s", imageRef, pubkey)
+func (v *ImageSignatureVerifier) getResultFromCache(resBundleRef, pubkey string) (bool, bool, string, *int64, error) {
+	key := fmt.Sprintf("cache/verify-image/%s/%s", resBundleRef, pubkey)
 	resultNum := 4
 	result, err := k8smnfutil.GetCache(key)
 	if err != nil {
@@ -166,8 +166,8 @@ func (v *ImageSignatureVerifier) getResultFromCache(imageRef, pubkey string) (bo
 	return true, verified, signerName, signedTimestamp, err
 }
 
-func (v *ImageSignatureVerifier) setResultToCache(imageRef, pubkey string, verified bool, signerName string, signedTimestamp *int64, err error) {
-	key := fmt.Sprintf("cache/verify-image/%s/%s", imageRef, pubkey)
+func (v *ImageSignatureVerifier) setResultToCache(resBundleRef, pubkey string, verified bool, signerName string, signedTimestamp *int64, err error) {
+	key := fmt.Sprintf("cache/verify-image/%s/%s", resBundleRef, pubkey)
 	setErr := k8smnfutil.SetCache(key, verified, signerName, signedTimestamp, err)
 	if setErr != nil {
 		log.Warn("cache set error: ", setErr.Error())
@@ -292,12 +292,12 @@ type ManifestFetcher interface {
 }
 
 // return a manifest fetcher.
-// `imageRef` is used for judging if manifest is inside an image or not.
+// `resBundleRef` is used for judging if manifest is inside an image or not.
 // `annotationConfig` is used for annotation domain config like "cosign.sigstore.dev".
 // `ignoreFields` and `maxResourceManifestNum` are used inside manifest detection logic.
-func NewManifestFetcher(imageRef, resourceRef string, annotationConfig AnnotationConfig, ignoreFields []string, maxResourceManifestNum int) ManifestFetcher {
-	if imageRef != "" {
-		return &ImageManifestFetcher{imageRefString: imageRef, AnnotationConfig: annotationConfig, ignoreFields: ignoreFields, maxResourceManifestNum: maxResourceManifestNum, cacheEnabled: true}
+func NewManifestFetcher(resBundleRef, resourceRef string, annotationConfig AnnotationConfig, ignoreFields []string, maxResourceManifestNum int) ManifestFetcher {
+	if resBundleRef != "" {
+		return &ImageManifestFetcher{resBundleRefString: resBundleRef, AnnotationConfig: annotationConfig, ignoreFields: ignoreFields, maxResourceManifestNum: maxResourceManifestNum, cacheEnabled: true}
 	} else {
 		return &BlobManifestFetcher{AnnotationConfig: annotationConfig, resourceRefString: resourceRef, ignoreFields: ignoreFields, maxResourceManifestNum: maxResourceManifestNum}
 	}
@@ -305,7 +305,7 @@ func NewManifestFetcher(imageRef, resourceRef string, annotationConfig Annotatio
 
 // ImageManifestFetcher is a fetcher implementation for image reference
 type ImageManifestFetcher struct {
-	imageRefString         string
+	resBundleRefString     string
 	AnnotationConfig       AnnotationConfig
 	ignoreFields           []string // used by ManifestSearchByValue()
 	maxResourceManifestNum int      // used by ManifestSearchByValue()
@@ -313,15 +313,15 @@ type ImageManifestFetcher struct {
 }
 
 func (f *ImageManifestFetcher) Fetch(objYAMLBytes []byte) ([][]byte, string, error) {
-	imageRefString := f.imageRefString
+	resBundleRefString := f.resBundleRefString
 	resBundleRefAnnotationKey := f.AnnotationConfig.ResourceBundleRefAnnotationKey()
-	if imageRefString == "" {
+	if resBundleRefString == "" {
 		annotations := k8smnfutil.GetAnnotationsInYAML(objYAMLBytes)
-		if annoImageRef, ok := annotations[resBundleRefAnnotationKey]; ok {
-			imageRefString = annoImageRef
+		if annoResBundleRef, ok := annotations[resBundleRefAnnotationKey]; ok {
+			resBundleRefString = annoResBundleRef
 		}
 	}
-	if imageRefString == "" {
+	if resBundleRefString == "" {
 		return nil, "", errors.New("no image reference is found")
 	}
 
@@ -330,40 +330,40 @@ func (f *ImageManifestFetcher) Fetch(objYAMLBytes []byte) ([][]byte, string, err
 		maxResourceManifestNumPtr = &f.maxResourceManifestNum
 	}
 
-	imageRefList := k8smnfutil.SplitCommaSeparatedString(imageRefString)
-	for _, imageRef := range imageRefList {
-		concatYAMLbytes, err := f.fetchManifestInSingleImage(imageRef)
+	resBundleRefList := k8smnfutil.SplitCommaSeparatedString(resBundleRefString)
+	for _, resBundleRef := range resBundleRefList {
+		concatYAMLbytes, err := f.fetchManifestInSingleImage(resBundleRef)
 		if err != nil {
 			return nil, "", err
 		}
 		found, resourceManifests := k8smnfutil.FindManifestYAML(concatYAMLbytes, objYAMLBytes, maxResourceManifestNumPtr, f.ignoreFields)
 		if found {
-			return resourceManifests, imageRef, nil
+			return resourceManifests, resBundleRef, nil
 		}
 	}
 	return nil, "", errors.New("failed to find a YAML manifest in the image")
 }
 
-func (f *ImageManifestFetcher) fetchManifestInSingleImage(singleImageRef string) ([]byte, error) {
+func (f *ImageManifestFetcher) fetchManifestInSingleImage(singleResourceBundleRef string) ([]byte, error) {
 	var concatYAMLbytes []byte
 	var err error
 	if f.cacheEnabled {
 		cacheFound := false
 		// try getting YAML manifests from cache
-		cacheFound, concatYAMLbytes, err = f.getManifestFromCache(singleImageRef)
+		cacheFound, concatYAMLbytes, err = f.getManifestFromCache(singleResourceBundleRef)
 		// if cache not found, do fetch and set the result to cache
 		if !cacheFound {
 			log.Debug("image manifest cache not found")
 			// fetch YAML manifests from actual image
-			concatYAMLbytes, err = f.getConcatYAMLFromImageRef(singleImageRef)
+			concatYAMLbytes, err = f.getConcatYAMLFromResourceBundleRef(singleResourceBundleRef)
 			if err == nil {
 				// set the result to cache
-				f.setManifestToCache(singleImageRef, concatYAMLbytes, err)
+				f.setManifestToCache(singleResourceBundleRef, concatYAMLbytes, err)
 			}
 		}
 	} else {
 		// fetch YAML manifests from actual image
-		concatYAMLbytes, err = f.getConcatYAMLFromImageRef(singleImageRef)
+		concatYAMLbytes, err = f.getConcatYAMLFromResourceBundleRef(singleResourceBundleRef)
 	}
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get YAMLs in the image")
@@ -372,12 +372,12 @@ func (f *ImageManifestFetcher) fetchManifestInSingleImage(singleImageRef string)
 }
 
 func (f *ImageManifestFetcher) FetchAll() ([][]byte, error) {
-	imageRefString := f.imageRefString
-	imageRefList := k8smnfutil.SplitCommaSeparatedString(imageRefString)
+	resBundleRefString := f.resBundleRefString
+	resBundleRefList := k8smnfutil.SplitCommaSeparatedString(resBundleRefString)
 
 	yamls := [][]byte{}
-	for _, imageRef := range imageRefList {
-		concatYAMLbytes, err := f.fetchManifestInSingleImage(imageRef)
+	for _, resBundleRef := range resBundleRefList {
+		concatYAMLbytes, err := f.fetchManifestInSingleImage(resBundleRef)
 		if err != nil {
 			return nil, err
 		}
@@ -387,8 +387,8 @@ func (f *ImageManifestFetcher) FetchAll() ([][]byte, error) {
 	return yamls, nil
 }
 
-func (f *ImageManifestFetcher) getConcatYAMLFromImageRef(imageRef string) ([]byte, error) {
-	image, err := k8smnfutil.PullImage(imageRef)
+func (f *ImageManifestFetcher) getConcatYAMLFromResourceBundleRef(resBundleRef string) ([]byte, error) {
+	image, err := k8smnfutil.PullImage(resBundleRef)
 	if err != nil {
 		return nil, err
 	}
@@ -399,8 +399,8 @@ func (f *ImageManifestFetcher) getConcatYAMLFromImageRef(imageRef string) ([]byt
 	return concatYAMLbytes, nil
 }
 
-func (f *ImageManifestFetcher) getManifestFromCache(imageRef string) (bool, []byte, error) {
-	key := fmt.Sprintf("cache/fetch-manifest/%s", imageRef)
+func (f *ImageManifestFetcher) getManifestFromCache(resBundleRef string) (bool, []byte, error) {
+	key := fmt.Sprintf("cache/fetch-manifest/%s", resBundleRef)
 	resultNum := 2
 	result, err := k8smnfutil.GetCache(key)
 	if err != nil {
@@ -426,8 +426,8 @@ func (f *ImageManifestFetcher) getManifestFromCache(imageRef string) (bool, []by
 	return true, concatYAMLbytes, err
 }
 
-func (f *ImageManifestFetcher) setManifestToCache(imageRef string, concatYAMLbytes []byte, err error) {
-	key := fmt.Sprintf("cache/fetch-manifest/%s", imageRef)
+func (f *ImageManifestFetcher) setManifestToCache(resBundleRef string, concatYAMLbytes []byte, err error) {
+	key := fmt.Sprintf("cache/fetch-manifest/%s", resBundleRef)
 	setErr := k8smnfutil.SetCache(key, concatYAMLbytes, err)
 	if setErr != nil {
 		log.Warn("cache set error: ", setErr.Error())

--- a/pkg/k8smanifest/verify_manifest.go
+++ b/pkg/k8smanifest/verify_manifest.go
@@ -43,8 +43,8 @@ func VerifyManifest(objManifest []byte, vo *VerifyManifestOption) (*VerifyResult
 	// use resourceBundleRef if specified in the annotation; otherwise follow the verify option
 	resBundleRefAnnotationKey := vo.AnnotationConfig.ResourceBundleRefAnnotationKey()
 	annotations := obj.GetAnnotations()
-	if annoImageRef, found := annotations[resBundleRefAnnotationKey]; found {
-		vo.ImageRef = annoImageRef
+	if annoResBundleRef, found := annotations[resBundleRefAnnotationKey]; found {
+		vo.ResourceBundleRef = annoResBundleRef
 	}
 
 	// add signature/message/others annotations to ignore fields
@@ -61,7 +61,7 @@ func VerifyManifest(objManifest []byte, vo *VerifyManifestOption) (*VerifyResult
 
 	var resourceManifests [][]byte
 	var sigRef string
-	resourceManifests, sigRef, err = NewManifestFetcher(vo.ImageRef, vo.SignatureResourceRef, vo.AnnotationConfig, ignoreFields, vo.MaxResourceManifestNum).Fetch(objManifest)
+	resourceManifests, sigRef, err = NewManifestFetcher(vo.ResourceBundleRef, vo.SignatureResourceRef, vo.AnnotationConfig, ignoreFields, vo.MaxResourceManifestNum).Fetch(objManifest)
 	if err != nil {
 		return nil, errors.Wrap(err, "reference YAML manifest not found for this manifest")
 	}

--- a/pkg/k8smanifest/verify_resource.go
+++ b/pkg/k8smanifest/verify_resource.go
@@ -72,8 +72,8 @@ func VerifyResource(obj unstructured.Unstructured, vo *VerifyResourceOption) (*V
 	// use resourceBundleRef if specified in the annotation; otherwise follow the verify option
 	resBundleRefAnnotationKey := vo.AnnotationConfig.ResourceBundleRefAnnotationKey()
 	annotations := obj.GetAnnotations()
-	if annoImageRef, found := annotations[resBundleRefAnnotationKey]; found {
-		vo.ImageRef = annoImageRef
+	if annoResBundleRef, found := annotations[resBundleRefAnnotationKey]; found {
+		vo.ResourceBundleRef = annoResBundleRef
 	}
 
 	// check if the resource should be skipped or not
@@ -97,7 +97,7 @@ func VerifyResource(obj unstructured.Unstructured, vo *VerifyResourceOption) (*V
 
 	var resourceManifests [][]byte
 	log.Debug("fetching manifest...")
-	resourceManifests, sigRef, err = NewManifestFetcher(vo.ImageRef, sigResourceRefString, vo.AnnotationConfig, ignoreFields, vo.MaxResourceManifestNum).Fetch(objBytes)
+	resourceManifests, sigRef, err = NewManifestFetcher(vo.ResourceBundleRef, sigResourceRefString, vo.AnnotationConfig, ignoreFields, vo.MaxResourceManifestNum).Fetch(objBytes)
 	if err != nil {
 		return nil, errors.Wrap(err, "YAML manifest not found for this resource")
 	}

--- a/pkg/k8smanifest/verify_test.go
+++ b/pkg/k8smanifest/verify_test.go
@@ -108,11 +108,6 @@ func TestVerifyResourceWithMultipleSignatures(t *testing.T) {
 			KeyPath: keyPath,
 		},
 	}
-	vo.AnnotationConfig = AnnotationConfig{
-		AdditionalSignatureKeysForVerify: []string{
-			"cosign2.sigstore.dev/signature-alt",
-		},
-	}
 
 	result, err := VerifyResource(obj, vo)
 	if err != nil {

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -28,9 +28,8 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"syscall"
-	"time"
 
+	filetimes "github.com/djherbis/times"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -285,10 +284,11 @@ func copyFile(src string, dst string) error {
 	}
 
 	// set the original timestamp metadata to generate consistent compression results everytime
-	mtime := fi.ModTime()
-	stat := fi.Sys().(*syscall.Stat_t)
-	atime := time.Unix(int64(stat.Atimespec.Sec), int64(stat.Atimespec.Nsec))
-	err = os.Chtimes(dst, atime, mtime)
+	tStat, err := filetimes.Stat(src)
+	if err != nil {
+		return err
+	}
+	err = os.Chtimes(dst, tStat.AccessTime(), tStat.ModTime())
 	if err != nil {
 		return err
 	}

--- a/pkg/util/image.go
+++ b/pkg/util/image.go
@@ -36,8 +36,8 @@ import (
 	"github.com/spf13/afero"
 )
 
-func PullImage(imageRef string) (v1.Image, error) {
-	ref, err := name.ParseReference(imageRef)
+func PullImage(resBundleRef string) (v1.Image, error) {
+	ref, err := name.ParseReference(resBundleRef)
 	if err != nil {
 		return nil, err
 	}
@@ -48,8 +48,8 @@ func PullImage(imageRef string) (v1.Image, error) {
 	return img, nil
 }
 
-func GetImageDigest(imageRef string) (string, error) {
-	ref, err := name.ParseReference(imageRef)
+func GetImageDigest(resBundleRef string) (string, error) {
+	ref, err := name.ParseReference(resBundleRef)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/util/kubeutil/kubeutil.go
+++ b/pkg/util/kubeutil/kubeutil.go
@@ -363,11 +363,11 @@ func contains(all []string, one string) bool {
 }
 
 type ImageObject struct {
-	PodName       string
-	ContainerName string
-	ImageID       string
-	ImageRef      string
-	Digest        string
+	PodName           string
+	ContainerName     string
+	ImageID           string
+	ResourceBundleRef string
+	Digest            string
 }
 
 func GetAllImagesFromObject(obj *unstructured.Unstructured) ([]ImageObject, error) {
@@ -381,25 +381,25 @@ func GetAllImagesFromObject(obj *unstructured.Unstructured) ([]ImageObject, erro
 		podName := p.GetName()
 		for _, cstatus := range p.Status.InitContainerStatuses {
 			containerName := cstatus.Name
-			imageRef := cstatus.Image
+			resBundleRef := cstatus.Image
 			imageID := cstatus.ImageID
-			if imageRef == "" || imageID == "" {
+			if resBundleRef == "" || imageID == "" {
 				continue
 			}
 			parts := strings.Split(imageID, "@")
 			imageDigest := parts[len(parts)-1]
-			images = append(images, ImageObject{PodName: podName, ContainerName: containerName, ImageID: imageID, ImageRef: imageRef, Digest: imageDigest})
+			images = append(images, ImageObject{PodName: podName, ContainerName: containerName, ImageID: imageID, ResourceBundleRef: resBundleRef, Digest: imageDigest})
 		}
 		for _, cstatus := range p.Status.ContainerStatuses {
 			containerName := cstatus.Name
-			imageRef := cstatus.Image
+			resBundleRef := cstatus.Image
 			imageID := cstatus.ImageID
-			if imageRef == "" || imageID == "" {
+			if resBundleRef == "" || imageID == "" {
 				continue
 			}
 			parts := strings.Split(imageID, "@")
 			imageDigest := parts[len(parts)-1]
-			images = append(images, ImageObject{PodName: podName, ContainerName: containerName, ImageID: imageID, ImageRef: imageRef, Digest: imageDigest})
+			images = append(images, ImageObject{PodName: podName, ContainerName: containerName, ImageID: imageID, ResourceBundleRef: resBundleRef, Digest: imageDigest})
 		}
 	}
 	return images, nil

--- a/pkg/util/manifestbuild/kustomize/provenance.go
+++ b/pkg/util/manifestbuild/kustomize/provenance.go
@@ -259,8 +259,8 @@ func resourceToMaterial(kr *KustomizationResource) *intotoprov02.ProvenanceMater
 }
 
 // returns image digest
-func GetImageDigest(imageRef string) (string, error) {
-	ref, err := name.ParseReference(imageRef)
+func GetImageDigest(resBundleRef string) (string, error) {
+	ref, err := name.ParseReference(resBundleRef)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/util/yaml.go
+++ b/pkg/util/yaml.go
@@ -37,6 +37,12 @@ import (
 
 const defaultmaxResourceManifestsNum = 3
 
+var supportedExtensions = map[string]bool{
+	".yaml":   true,
+	".yml":    true,
+	".signed": true,
+}
+
 type ResourceInfo struct {
 	group     string
 	version   string
@@ -60,7 +66,7 @@ func FindYAMLsInDir(dirPath string) ([][]byte, error) {
 
 	foundYAMLs := [][]byte{}
 	err := filepath.Walk(dirPath, func(fpath string, info os.FileInfo, err error) error {
-		if err == nil && (path.Ext(info.Name()) == ".yaml" || path.Ext(info.Name()) == ".yml") {
+		if err == nil && supportedExtensions[path.Ext(info.Name())] {
 			yamlBytes, err := ioutil.ReadFile(fpath)
 			if err == nil && isK8sResourceYAML(yamlBytes) {
 				foundYAMLs = append(foundYAMLs, yamlBytes)


### PR DESCRIPTION
Signed-off-by: Hirokuni-Kitahara1 <hirokuni.kitahara1@ibm.com>

- users can sign their YAML manifest with `--append-signature` (or `-A`) option. This allows the signed manifest to store multiple signatures in the annotation without removing the pre-existing signatures. `signature_1`, `signature_2` ... will be automatically added if the option is enabled while signing.
- users can verify their YAML manifest / Kubernetes resource that have multiple signatures in the annotation.
- fix an issue of making message data so that consistent message data can be used when the same file is signed multiple times.
- add test cases