### PR TITLE
make the current signing method with tarball deprecated

### DIFF
--- a/cmd/kubectl-sigstore/cli/sign.go
+++ b/cmd/kubectl-sigstore/cli/sign.go
@@ -38,14 +38,15 @@ func NewCmdSign() *cobra.Command {
 	var output string
 	var applySignatureConfigMap bool
 	var updateAnnotation bool
-	var rawSigning bool
+	var tarballOpt string
 	var imageAnnotations []string
 	cmd := &cobra.Command{
 		Use:   "sign -f FILENAME [-i IMAGE]",
 		Short: "A command to sign Kubernetes YAML manifests",
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			err := sign(inputDir, imageRef, keyPath, output, applySignatureConfigMap, updateAnnotation, rawSigning, imageAnnotations)
+			makeTarball := (tarballOpt == "yes")
+			err := sign(inputDir, imageRef, keyPath, output, applySignatureConfigMap, updateAnnotation, makeTarball, imageAnnotations)
 			if err != nil {
 				log.Fatalf("error occurred during signing: %s", err.Error())
 				return nil
@@ -60,13 +61,13 @@ func NewCmdSign() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&keyPath, "key", "k", "", "path to your signing key (if empty, do key-less signing)")
 	cmd.PersistentFlags().BoolVar(&applySignatureConfigMap, "apply-signature-configmap", false, "whether to apply a generated signature configmap only when `output` is k8s configmap")
 	cmd.PersistentFlags().BoolVar(&updateAnnotation, "annotation-metadata", true, "whether to update annotation and generate signed yaml file")
-	cmd.PersistentFlags().BoolVarP(&rawSigning, "raw-sign", "r", false, "enable a new signing method which does not do tarball compression for signing (this will be default: true in v0.5.0+)")
+	cmd.PersistentFlags().StringVar(&tarballOpt, "tarball", "yes", "whether to make a tarball for signing (this will be default to \"no\" in v0.5.0+)")
 	cmd.PersistentFlags().StringArrayVarP(&imageAnnotations, "annotation", "a", []string{}, "extra key=value pairs to sign")
 
 	return cmd
 }
 
-func sign(inputDir, imageRef, keyPath, output string, applySignatureConfigMap, updateAnnotation, rawSigning bool, annotations []string) error {
+func sign(inputDir, imageRef, keyPath, output string, applySignatureConfigMap, updateAnnotation, tarball bool, annotations []string) error {
 	if output == "" && updateAnnotation {
 		if isDir, _ := k8smnfutil.IsDir(inputDir); isDir {
 			// e.g.) "./yamls/" --> "./yamls/manifest.yaml.signed"
@@ -91,7 +92,7 @@ func sign(inputDir, imageRef, keyPath, output string, applySignatureConfigMap, u
 		KeyPath:          keyPath,
 		Output:           output,
 		UpdateAnnotation: updateAnnotation,
-		RawSigning:       rawSigning,
+		Tarball:          &tarball,
 		ImageAnnotations: anntns,
 	}
 

--- a/cmd/kubectl-sigstore/cli/sign.go
+++ b/cmd/kubectl-sigstore/cli/sign.go
@@ -38,13 +38,14 @@ func NewCmdSign() *cobra.Command {
 	var output string
 	var applySignatureConfigMap bool
 	var updateAnnotation bool
+	var rawSigning bool
 	var imageAnnotations []string
 	cmd := &cobra.Command{
 		Use:   "sign -f FILENAME [-i IMAGE]",
 		Short: "A command to sign Kubernetes YAML manifests",
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			err := sign(inputDir, imageRef, keyPath, output, applySignatureConfigMap, updateAnnotation, imageAnnotations)
+			err := sign(inputDir, imageRef, keyPath, output, applySignatureConfigMap, updateAnnotation, rawSigning, imageAnnotations)
 			if err != nil {
 				log.Fatalf("error occurred during signing: %s", err.Error())
 				return nil
@@ -59,12 +60,13 @@ func NewCmdSign() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&keyPath, "key", "k", "", "path to your signing key (if empty, do key-less signing)")
 	cmd.PersistentFlags().BoolVar(&applySignatureConfigMap, "apply-signature-configmap", false, "whether to apply a generated signature configmap only when `output` is k8s configmap")
 	cmd.PersistentFlags().BoolVar(&updateAnnotation, "annotation-metadata", true, "whether to update annotation and generate signed yaml file")
+	cmd.PersistentFlags().BoolVarP(&rawSigning, "raw-sign", "r", false, "enable a new signing method which does not do tarball compression for signing (this will be default: true in v0.5.0+)")
 	cmd.PersistentFlags().StringArrayVarP(&imageAnnotations, "annotation", "a", []string{}, "extra key=value pairs to sign")
 
 	return cmd
 }
 
-func sign(inputDir, imageRef, keyPath, output string, applySignatureConfigMap, updateAnnotation bool, annotations []string) error {
+func sign(inputDir, imageRef, keyPath, output string, applySignatureConfigMap, updateAnnotation, rawSigning bool, annotations []string) error {
 	if output == "" && updateAnnotation {
 		if isDir, _ := k8smnfutil.IsDir(inputDir); isDir {
 			// e.g.) "./yamls/" --> "./yamls/manifest.yaml.signed"
@@ -89,6 +91,7 @@ func sign(inputDir, imageRef, keyPath, output string, applySignatureConfigMap, u
 		KeyPath:          keyPath,
 		Output:           output,
 		UpdateAnnotation: updateAnnotation,
+		RawSigning:       rawSigning,
 		ImageAnnotations: anntns,
 	}
 

--- a/cmd/kubectl-sigstore/cli/sign_test.go
+++ b/cmd/kubectl-sigstore/cli/sign_test.go
@@ -54,7 +54,7 @@ func TestSign(t *testing.T) {
 
 	fpath := "testdata/sample-configmap.yaml"
 	outPath := filepath.Join(tmpDir, "sample-configmap.yaml.signed")
-	err = sign(fpath, "", keyPath, outPath, false, true, false, nil)
+	err = sign(fpath, "", keyPath, outPath, false, true, true, nil)
 	if err != nil {
 		t.Errorf("failed to sign the test file: %s", err.Error())
 		return
@@ -68,7 +68,7 @@ func TestSign(t *testing.T) {
 
 	fpath2 := "testdata/sample-configmap-concat.yaml"
 	outPath2 := filepath.Join(tmpDir, "sample-configmap-concat.yaml.signed")
-	err = sign(fpath2, "", keyPath, outPath2, false, true, false, nil)
+	err = sign(fpath2, "", keyPath, outPath2, false, true, true, nil)
 	if err != nil {
 		t.Errorf("failed to sign the test file: %s", err.Error())
 		return

--- a/cmd/kubectl-sigstore/cli/sign_test.go
+++ b/cmd/kubectl-sigstore/cli/sign_test.go
@@ -54,7 +54,7 @@ func TestSign(t *testing.T) {
 
 	fpath := "testdata/sample-configmap.yaml"
 	outPath := filepath.Join(tmpDir, "sample-configmap.yaml.signed")
-	err = sign(fpath, "", keyPath, outPath, false, true, nil)
+	err = sign(fpath, "", keyPath, outPath, false, true, false, nil)
 	if err != nil {
 		t.Errorf("failed to sign the test file: %s", err.Error())
 		return
@@ -68,7 +68,7 @@ func TestSign(t *testing.T) {
 
 	fpath2 := "testdata/sample-configmap-concat.yaml"
 	outPath2 := filepath.Join(tmpDir, "sample-configmap-concat.yaml.signed")
-	err = sign(fpath2, "", keyPath, outPath2, false, true, nil)
+	err = sign(fpath2, "", keyPath, outPath2, false, true, false, nil)
 	if err != nil {
 		t.Errorf("failed to sign the test file: %s", err.Error())
 		return

--- a/pkg/k8smanifest/option.go
+++ b/pkg/k8smanifest/option.go
@@ -50,7 +50,7 @@ type SignOption struct {
 	ImageAnnotations  map[string]interface{} `json:"-"`
 	PassFunc          cosign.PassFunc        `json:"-"`
 	ApplySigConfigMap bool                   `json:"-"`
-	RawSigning        bool                   `json:"-"`
+	Tarball           *bool                  `json:"-"`
 }
 
 // option for VerifyResource()

--- a/pkg/k8smanifest/option.go
+++ b/pkg/k8smanifest/option.go
@@ -50,6 +50,7 @@ type SignOption struct {
 	ImageAnnotations  map[string]interface{} `json:"-"`
 	PassFunc          cosign.PassFunc        `json:"-"`
 	ApplySigConfigMap bool                   `json:"-"`
+	RawSigning        bool                   `json:"-"`
 }
 
 // option for VerifyResource()

--- a/pkg/k8smanifest/sign.go
+++ b/pkg/k8smanifest/sign.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -55,12 +56,16 @@ const (
 
 func Sign(inputDir string, so *SignOption) ([]byte, error) {
 
+	if !so.RawSigning {
+		log.Warn("[DEPRECATED] This signing method is deprecated in v0.3.1+, and will be unavailable in v0.5.0. You can use the new method by `--raw-sign` from CLI or `RawSign = true` in SignOption from codes.")
+	}
+
 	output := ""
 	if so.UpdateAnnotation {
 		output = so.Output
 	}
 
-	signedBytes, err := NewSigner(so.ImageRef, so.KeyPath, so.CertPath, output, so.ApplySigConfigMap, so.AnnotationConfig, so.PassFunc).Sign(inputDir, output, so.ImageAnnotations)
+	signedBytes, err := NewSigner(so.ImageRef, so.KeyPath, so.CertPath, output, so.ApplySigConfigMap, so.RawSigning, so.AnnotationConfig, so.PassFunc).Sign(inputDir, output, so.ImageAnnotations)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to sign the specified content")
 	}
@@ -72,7 +77,7 @@ type Signer interface {
 	Sign(inputDir, output string, imageAnnotations map[string]interface{}) ([]byte, error)
 }
 
-func NewSigner(imageRef, keyPath, certPath, output string, doApply bool, AnnotationConfig AnnotationConfig, pf cosign.PassFunc) Signer {
+func NewSigner(imageRef, keyPath, certPath, output string, doApply, rawSigning bool, AnnotationConfig AnnotationConfig, pf cosign.PassFunc) Signer {
 	var prikeyPath *string
 	if keyPath != "" {
 		prikeyPath = &keyPath
@@ -86,14 +91,15 @@ func NewSigner(imageRef, keyPath, certPath, output string, doApply bool, Annotat
 		createSigConfigMap = true
 	}
 	if imageRef != "" {
-		return &ImageSigner{AnnotationConfig: AnnotationConfig, imageRef: imageRef, prikeyPath: prikeyPath, certPath: certPathP, passFunc: pf}
+		return &ImageSigner{AnnotationConfig: AnnotationConfig, imageRef: imageRef, rawSigning: rawSigning, prikeyPath: prikeyPath, certPath: certPathP, passFunc: pf}
 	} else {
-		return &BlobSigner{AnnotationConfig: AnnotationConfig, createSigConfigMap: createSigConfigMap, doApply: doApply, prikeyPath: prikeyPath, certPath: certPathP, passFunc: pf}
+		return &BlobSigner{AnnotationConfig: AnnotationConfig, createSigConfigMap: createSigConfigMap, doApply: doApply, rawSigning: rawSigning, prikeyPath: prikeyPath, certPath: certPathP, passFunc: pf}
 	}
 }
 
 type ImageSigner struct {
 	AnnotationConfig AnnotationConfig
+	rawSigning       bool
 	imageRef         string
 	prikeyPath       *string
 	certPath         *string
@@ -106,9 +112,17 @@ func (s *ImageSigner) Sign(inputDir, output string, imageAnnotations map[string]
 	if len(imageAnnotations) > 0 {
 		mo = &k8ssigutil.MutateOptions{AW: embedAnnotation, Annotations: imageAnnotations}
 	}
-	err := k8ssigutil.TarGzCompress(inputDir, &inputDataBuffer, mo)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to compress an input file/dir")
+	var err error
+	if s.rawSigning {
+		err = makeMessageYAML(inputDir, &inputDataBuffer, mo)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to make a message YAML from the input file/dir")
+		}
+	} else {
+		err = k8ssigutil.TarGzCompress(inputDir, &inputDataBuffer, mo)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to compress an input file/dir")
+		}
 	}
 	var signedBytes []byte
 	// upload files as image
@@ -139,6 +153,7 @@ type BlobSigner struct {
 	AnnotationConfig   AnnotationConfig
 	createSigConfigMap bool
 	doApply            bool
+	rawSigning         bool
 	prikeyPath         *string
 	certPath           *string
 	passFunc           cosign.PassFunc
@@ -158,9 +173,16 @@ func (s *BlobSigner) Sign(inputDir, output string, imageAnnotations map[string]i
 		mo = &k8ssigutil.MutateOptions{AW: embedAnnotation, Annotations: imageAnnotations}
 	}
 
-	err = k8ssigutil.TarGzCompress(inputDir, &inputDataBuffer, mo)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to compress an input file/dir")
+	if s.rawSigning {
+		err = makeMessageYAML(inputDir, &inputDataBuffer, mo)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to make a message YAML from the input file/dir")
+		}
+	} else {
+		err = k8ssigutil.TarGzCompress(inputDir, &inputDataBuffer, mo)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to compress an input file/dir")
+		}
 	}
 	var signedBytes []byte
 	var sigMaps map[string][]byte
@@ -205,6 +227,20 @@ func (s *BlobSigner) Sign(inputDir, output string, imageAnnotations map[string]i
 		}
 	}
 	return signedBytes, nil
+}
+
+// load the input dir/file, remove signature annotations and generate a single yaml with all the resources
+func makeMessageYAML(inputDir string, outBuffer *bytes.Buffer, moList ...*k8ssigutil.MutateOptions) error {
+	yamls, err := k8ssigutil.LoadYAMLsInDirWithMutationOptions(inputDir, moList...)
+	if err != nil {
+		return errors.Wrap(err, "failed to load an input file/dir")
+	}
+	singleYAML := k8ssigutil.ConcatenateYAMLs(yamls)
+	_, err = outBuffer.Write(singleYAML)
+	if err != nil {
+		return errors.Wrap(err, "failed to write loaded yaml into buffer")
+	}
+	return nil
 }
 
 func uploadFileToRegistry(inputData []byte, imageRef string) error {

--- a/pkg/k8smanifest/sign_test.go
+++ b/pkg/k8smanifest/sign_test.go
@@ -62,7 +62,7 @@ func TestSign(t *testing.T) {
 	t.Logf("signed YAML file: %s", string(signedBytes))
 }
 
-func TestRawSign(t *testing.T) {
+func TestNonTarballSign(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "k8smanifest-sign-test")
 	if err != nil {
 		t.Errorf("failed to create temp dir: %s", err.Error())
@@ -81,19 +81,20 @@ func TestRawSign(t *testing.T) {
 	fpath := "testdata/sample-configmap.yaml"
 	outPath := filepath.Join(tmpDir, "sample-configmap-raw.yaml.signed")
 
+	falseVar := false
 	so := &SignOption{
 		KeyPath:          keyPath,
 		Output:           outPath,
-		RawSigning:       true,
+		Tarball:          &falseVar,
 		UpdateAnnotation: true,
 	}
 
 	signedBytes, err := Sign(fpath, so)
 	if err != nil {
-		t.Errorf("failed to sign the test file by raw sign: %s", err.Error())
+		t.Errorf("failed to sign the test file by non-tarball sign: %s", err.Error())
 		return
 	}
-	t.Logf("signed YAML file by raw sign: %s", string(signedBytes))
+	t.Logf("signed YAML file by non-tarball sign: %s", string(signedBytes))
 }
 
 func initSingleTestFile(b64EncodedData []byte, fpath string) error {

--- a/pkg/k8smanifest/sign_test.go
+++ b/pkg/k8smanifest/sign_test.go
@@ -62,7 +62,7 @@ func TestSign(t *testing.T) {
 	t.Logf("signed YAML file: %s", string(signedBytes))
 }
 
-func TestDirectSign(t *testing.T) {
+func TestRawSign(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "k8smanifest-sign-test")
 	if err != nil {
 		t.Errorf("failed to create temp dir: %s", err.Error())
@@ -79,7 +79,7 @@ func TestDirectSign(t *testing.T) {
 	}
 
 	fpath := "testdata/sample-configmap.yaml"
-	outPath := filepath.Join(tmpDir, "sample-configmap-direct.yaml.signed")
+	outPath := filepath.Join(tmpDir, "sample-configmap-raw.yaml.signed")
 
 	so := &SignOption{
 		KeyPath:          keyPath,
@@ -90,10 +90,10 @@ func TestDirectSign(t *testing.T) {
 
 	signedBytes, err := Sign(fpath, so)
 	if err != nil {
-		t.Errorf("failed to sign the test file by direct sign: %s", err.Error())
+		t.Errorf("failed to sign the test file by raw sign: %s", err.Error())
 		return
 	}
-	t.Logf("signed YAML file by direct sign: %s", string(signedBytes))
+	t.Logf("signed YAML file by raw sign: %s", string(signedBytes))
 }
 
 func initSingleTestFile(b64EncodedData []byte, fpath string) error {

--- a/pkg/util/yaml.go
+++ b/pkg/util/yaml.go
@@ -74,6 +74,28 @@ func FindYAMLsInDir(dirPath string) ([][]byte, error) {
 	return foundYAMLs, nil
 }
 
+func LoadYAMLsInDirWithMutationOptions(dirPath string, moList ...*MutateOptions) ([][]byte, error) {
+	yamls, err := FindYAMLsInDir(dirPath)
+	if err != nil {
+		return nil, err
+	}
+	mYamls := [][]byte{}
+	for _, yaml := range yamls {
+		mYaml := yaml
+		for _, mo := range moList {
+			if mo == nil {
+				continue
+			}
+			mYaml, err = mo.AW(mYaml, mo.Annotations)
+			if err != nil {
+				return nil, err
+			}
+		}
+		mYamls = append(mYamls, mYaml)
+	}
+	return mYamls, nil
+}
+
 // Out of `concatYamlBytes`, find YAML manifests that are corresponding to the `objBytes`.
 // `maxResourceManifestNum` determines how many candidate manifests can be returned. If empty, default to 3.
 // `ignoreFields` is used for value based search, the specified fields are ignored on the comparison.


### PR DESCRIPTION
Signed-off-by: Hirokuni-Kitahara1 <hirokuni.kitahara1@ibm.com>

- The current signing method creates a tarball from the input YAML manifest / the input directory for signing, but this causes non-reproducible message serialization and it makes `message` annotation in the signed manifest difficult to check.
- Instead, we add a new signing method which directly signs the raw YAML manifest (or raw manifests in the directory) and it is enabled by `--tarball=no` option with this PR.
- We make the current method deprecated in the next release (v0.3.1) and it will be unavailable in v0.5.0. Once it becomes unavailable, the new signing method will be the default one.