### PR TITLE
fix keyless signing issue that tlog entry cannot be got after signing

### DIFF
--- a/pkg/cosign/sign.go
+++ b/pkg/cosign/sign.go
@@ -276,7 +276,7 @@ func GetRekorServerURL() string {
 	return url
 }
 
-// cosign has a bug for the function as of v1.9.0, so use this instead here
+// cosign has a bug in GetTlogEntry() function as of v1.9.0, so use this instead here
 func GetTlogEntry(ctx context.Context, rekorClient *rekorgenclient.Rekor, uuid string) (*models.LogEntryAnon, error) {
 	params := entries.NewGetLogEntryByUUIDParamsWithContext(ctx)
 	params.SetEntryUUID(uuid)


### PR DESCRIPTION
Signed-off-by: Hirokuni-Kitahara1 <hirokuni.kitahara1@ibm.com>

- add workaround for a bug in `GetTlogEntry()` function in cosign
- set keyless default timeout to the default value of cosign