### PR TITLE
add sign & verify options to support cosign command options

### DIFF
--- a/cmd/kubectl-sigstore/cli/apply_after_verify.go
+++ b/cmd/kubectl-sigstore/cli/apply_after_verify.go
@@ -136,9 +136,9 @@ func applyAfterVerify(filename, resBundleRef, keyPath, configPath string) error 
 
 	if verified {
 		if signerName == "" {
-			log.Infof("verifed: %s", strconv.FormatBool(verified))
+			log.Infof("verified: %s", strconv.FormatBool(verified))
 		} else {
-			log.Infof("verifed: %s, signerName: %s", strconv.FormatBool(verified), signerName)
+			log.Infof("verified: %s, signerName: %s", strconv.FormatBool(verified), signerName)
 		}
 		err := KOptions.Apply(filename)
 		if err != nil {
@@ -151,7 +151,7 @@ func applyAfterVerify(filename, resBundleRef, keyPath, configPath string) error 
 		} else {
 			errMsg = diffMsg
 		}
-		log.Fatalf("verifed: %s, error: %s", strconv.FormatBool(verified), errMsg)
+		log.Fatalf("verified: %s, error: %s", strconv.FormatBool(verified), errMsg)
 	}
 
 	return nil

--- a/cmd/kubectl-sigstore/cli/sign_test.go
+++ b/cmd/kubectl-sigstore/cli/sign_test.go
@@ -53,7 +53,7 @@ func TestSign(t *testing.T) {
 
 	fpath := "testdata/sample-configmap.yaml"
 	outPath := filepath.Join(tmpDir, "sample-configmap.yaml.signed")
-	err = sign(fpath, "", keyPath, outPath, false, false, true, true, nil)
+	err = sign(fpath, "", keyPath, "", outPath, false, false, true, true, nil)
 	if err != nil {
 		t.Errorf("failed to sign the test file: %s", err.Error())
 		return
@@ -67,7 +67,7 @@ func TestSign(t *testing.T) {
 
 	fpath2 := "testdata/sample-configmap-concat.yaml"
 	outPath2 := filepath.Join(tmpDir, "sample-configmap-concat.yaml.signed")
-	err = sign(fpath2, "", keyPath, outPath2, false, false, true, true, nil)
+	err = sign(fpath2, "", keyPath, "", outPath2, false, false, true, true, nil)
 	if err != nil {
 		t.Errorf("failed to sign the test file: %s", err.Error())
 		return

--- a/cmd/kubectl-sigstore/cli/verify_resource_test.go
+++ b/cmd/kubectl-sigstore/cli/verify_resource_test.go
@@ -207,7 +207,7 @@ var _ = Describe("Test Kubeutil Sigstore Functions", func() {
 				return err
 			}
 
-			verified, err := verifyResource(nil, []string{"cm", "sample-cm"}, "", "", "", "", "", "", false, false, "", "", 4)
+			verified, err := verifyResource(nil, []string{"cm", "sample-cm"}, "", "", "", "", "", "", false, false, "", "", "", "", "", "", 4)
 			if err != nil {
 				return err
 			}
@@ -227,7 +227,7 @@ var _ = Describe("Test Kubeutil Sigstore Functions", func() {
 			}
 
 			pubkeyPath := filepath.Join(testTempDir, "testpub")
-			verified, err := verifyResource(nil, []string{"cm", "sample-cm-signed"}, "", "", pubkeyPath, "", "", "", false, false, "", "json", 4)
+			verified, err := verifyResource(nil, []string{"cm", "sample-cm-signed"}, "", "", pubkeyPath, "", "", "", false, false, "", "", "", "", "", "json", 4)
 			if err != nil {
 				return err
 			}

--- a/pkg/cosign/sign.go
+++ b/pkg/cosign/sign.go
@@ -52,12 +52,17 @@ const (
 	defaultKeylessTlogUploadTimeout = 90 // set to 90s for keyless as cosign recommends it in the help message
 )
 
-func SignImage(resBundleRef string, keyPath, certPath *string, pf cosign.PassFunc, imageAnnotations map[string]interface{}) error {
+func SignImage(resBundleRef string, keyPath, certPath *string, rekorURL string, pf cosign.PassFunc, imageAnnotations map[string]interface{}) error {
 	// TODO: add support for sk (security key) and idToken (identity token for cert from fulcio)
 	sk := false
 	idToken := ""
 
-	rekorSeverURL := GetRekorServerURL()
+	var rekorSeverURL string
+	if rekorURL == "" {
+		rekorSeverURL = GetRekorServerURL()
+	} else {
+		rekorSeverURL = rekorURL
+	}
 	fulcioServerURL := fulcioapi.SigstorePublicServerURL
 
 	rootOpt := &cliopt.RootOptions{Timeout: defaultTlogUploadTimeout * time.Second}
@@ -92,12 +97,17 @@ func SignImage(resBundleRef string, keyPath, certPath *string, pf cosign.PassFun
 	return clisign.SignCmd(rootOpt, opt, regOpt, imageAnnotations, []string{resBundleRef}, certPathStr, "", true, outputSignaturePath, outputCertificatePath, "", false, false, "")
 }
 
-func SignBlob(blobPath string, keyPath, certPath *string, pf cosign.PassFunc) (map[string][]byte, error) {
+func SignBlob(blobPath string, keyPath, certPath *string, rekorURL string, pf cosign.PassFunc) (map[string][]byte, error) {
 	// TODO: add support for sk (security key) and idToken (identity token for cert from fulcio)
 	sk := false
 	idToken := ""
 
-	rekorSeverURL := GetRekorServerURL()
+	var rekorSeverURL string
+	if rekorURL == "" {
+		rekorSeverURL = GetRekorServerURL()
+	} else {
+		rekorSeverURL = rekorURL
+	}
 	fulcioServerURL := fulcioapi.SigstorePublicServerURL
 
 	opt := cliopt.KeyOpts{

--- a/pkg/cosign/sign_test.go
+++ b/pkg/cosign/sign_test.go
@@ -63,7 +63,7 @@ func TestSignBlob(t *testing.T) {
 	blobPath := files["blob"].fpath
 	keyPath := files["key"].fpath
 
-	sigMap, err := SignBlob(blobPath, &keyPath, nil, passFuncForTest)
+	sigMap, err := SignBlob(blobPath, &keyPath, nil, "", passFuncForTest)
 	if err != nil {
 		t.Errorf("failed to load test files: %s", err.Error())
 		return

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -47,7 +47,7 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature/payload"
 )
 
-func VerifyImage(resBundleRef, pubkeyPath, certRef, certChain, rekorURL, oidcIssuer string) (bool, string, *int64, error) {
+func VerifyImage(resBundleRef, pubkeyPath, certRef, certChain, rekorURL, oidcIssuer string, rootCerts *x509.CertPool) (bool, string, *int64, error) {
 	ref, err := name.ParseReference(resBundleRef)
 	if err != nil {
 		return false, "", nil, fmt.Errorf("failed to parse image ref `%s`; %s", resBundleRef, err.Error())
@@ -77,9 +77,13 @@ func VerifyImage(resBundleRef, pubkeyPath, certRef, certChain, rekorURL, oidcIss
 			return false, "", nil, fmt.Errorf("failed to initialize rekor client; %s", err.Error())
 		}
 		co.RekorClient = rekorClient
-		co.RootCerts, err = fulcio.GetRoots()
-		if err != nil {
-			return false, "", nil, fmt.Errorf("failed to get fulcio root; %s", err.Error())
+		if rootCerts != nil {
+			co.RootCerts = rootCerts
+		} else {
+			co.RootCerts, err = fulcio.GetRoots()
+			if err != nil {
+				return false, "", nil, fmt.Errorf("failed to get fulcio root; %s", err.Error())
+			}
 		}
 		co.CertOidcIssuer = oidcIssuer
 	}

--- a/pkg/cosign/verify_test.go
+++ b/pkg/cosign/verify_test.go
@@ -37,7 +37,7 @@ func TestVerifyBlob(t *testing.T) {
 		t.Errorf("failed to load pub key: %s", err.Error())
 		return
 	}
-	verified, _, _, err := VerifyBlob(b64EncodedTestBlob, b64EncodedTestSig, nil, nil, &pubkeyPath)
+	verified, _, _, err := VerifyBlob(b64EncodedTestBlob, b64EncodedTestSig, nil, nil, &pubkeyPath, "", "", "", "")
 	if err != nil {
 		t.Errorf("failed to verify signature with error: %s", err.Error())
 		return

--- a/pkg/k8smanifest/option.go
+++ b/pkg/k8smanifest/option.go
@@ -40,7 +40,8 @@ var defaultConfigBytes []byte
 
 // option for Sign()
 type SignOption struct {
-	commonOption `json:""`
+	commonOption     `json:""`
+	cosignSignOption `json:""`
 
 	// these options should be input from CLI arguments
 	KeyPath           string                 `json:"-"`
@@ -57,9 +58,11 @@ type SignOption struct {
 
 // option for VerifyResource()
 type VerifyResourceOption struct {
-	commonOption `json:""`
-	verifyOption `json:""`
-	SkipObjects  ObjectReferenceList `json:"skipObjects,omitempty"`
+	commonOption       `json:""`
+	verifyOption       `json:""`
+	cosignVerifyOption `json:""`
+
+	SkipObjects ObjectReferenceList `json:"skipObjects,omitempty"`
 
 	Provenance            bool   `json:"-"`
 	DisableDryRun         bool   `json:"-"`
@@ -77,8 +80,9 @@ func (o *VerifyResourceOption) SetAnnotationIgnoreFields() {
 
 // option for VerifyManifest()
 type VerifyManifestOption struct {
-	commonOption `json:""`
-	verifyOption `json:""`
+	commonOption       `json:""`
+	verifyOption       `json:""`
+	cosignVerifyOption `json:""`
 }
 
 func (o *VerifyManifestOption) SetAnnotationIgnoreFields() {
@@ -121,6 +125,19 @@ func (o verifyOption) isAnnotationKeyAlreadySetToIgnoreFields() bool {
 // common options
 type commonOption struct {
 	AnnotationConfig `json:""`
+}
+
+// cosign sign option
+type cosignSignOption struct {
+	RekorURL string `json:"-"`
+}
+
+// cosign verify option
+type cosignVerifyOption struct {
+	Certificate      string `json:"-"`
+	CertificateChain string `json:"-"`
+	RekorURL         string `json:"-"`
+	OIDCIssuer       string `json:"-"`
 }
 
 // annotation config for signing and verification

--- a/pkg/k8smanifest/option.go
+++ b/pkg/k8smanifest/option.go
@@ -17,6 +17,7 @@
 package k8smanifest
 
 import (
+	"crypto/x509"
 	_ "embed"
 	"encoding/json"
 	"fmt"
@@ -134,10 +135,11 @@ type cosignSignOption struct {
 
 // cosign verify option
 type cosignVerifyOption struct {
-	Certificate      string `json:"-"`
-	CertificateChain string `json:"-"`
-	RekorURL         string `json:"-"`
-	OIDCIssuer       string `json:"-"`
+	Certificate      string         `json:"-"`
+	CertificateChain string         `json:"-"`
+	RekorURL         string         `json:"-"`
+	OIDCIssuer       string         `json:"-"`
+	RootCerts        *x509.CertPool `json:"-"`
 }
 
 // annotation config for signing and verification

--- a/pkg/k8smanifest/verify.go
+++ b/pkg/k8smanifest/verify.go
@@ -17,6 +17,7 @@
 package k8smanifest
 
 import (
+	cryptox509 "crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -50,6 +51,7 @@ type CosignVerifyConfig struct {
 	CertChain  string
 	RekorURL   string
 	OIDCIssuer string
+	RootCerts  *cryptox509.CertPool
 }
 
 func NewSignatureVerifier(objYAMLBytes []byte, sigRef string, pubkeyPath *string, signers []string, cosignVerifyConfig CosignVerifyConfig, annotationConfig AnnotationConfig) SignatureVerifier {
@@ -149,7 +151,7 @@ func (v *ImageSignatureVerifier) Verify() (bool, string, *int64, error) {
 	for i := range v.identityList {
 		identity := v.identityList[i]
 		// do normal image verification
-		verified, signerName, signedTimestamp, err = k8smnfcosign.VerifyImage(resBundleRef, identity.path, v.CertRef, v.CertChain, v.RekorURL, v.OIDCIssuer)
+		verified, signerName, signedTimestamp, err = k8smnfcosign.VerifyImage(resBundleRef, identity.path, v.CertRef, v.CertChain, v.RekorURL, v.OIDCIssuer, v.RootCerts)
 
 		// cosign keyless returns signerName, so check if it matches the verificationIdentity
 		if verified && identity.name != "" {

--- a/pkg/k8smanifest/verify_manifest.go
+++ b/pkg/k8smanifest/verify_manifest.go
@@ -94,7 +94,14 @@ func VerifyManifest(objManifest []byte, vo *VerifyManifestOption) (*VerifyResult
 		signers = vo.Signers
 	}
 
-	sigVerified, signerName, _, err := NewSignatureVerifier(objManifest, sigRef, keyPath, signers, vo.AnnotationConfig).Verify()
+	cosignVerifyConfig := CosignVerifyConfig{
+		CertRef:    vo.Certificate,
+		CertChain:  vo.CertificateChain,
+		RekorURL:   vo.RekorURL,
+		OIDCIssuer: vo.OIDCIssuer,
+	}
+
+	sigVerified, signerName, _, err := NewSignatureVerifier(objManifest, sigRef, keyPath, signers, cosignVerifyConfig, vo.AnnotationConfig).Verify()
 	if err != nil {
 		return nil, errors.Wrap(err, "error occured during signature verification")
 	}

--- a/pkg/k8smanifest/verify_manifest.go
+++ b/pkg/k8smanifest/verify_manifest.go
@@ -99,6 +99,7 @@ func VerifyManifest(objManifest []byte, vo *VerifyManifestOption) (*VerifyResult
 		CertChain:  vo.CertificateChain,
 		RekorURL:   vo.RekorURL,
 		OIDCIssuer: vo.OIDCIssuer,
+		RootCerts:  vo.RootCerts,
 	}
 
 	sigVerified, signerName, _, err := NewSignatureVerifier(objManifest, sigRef, keyPath, signers, cosignVerifyConfig, vo.AnnotationConfig).Verify()

--- a/pkg/k8smanifest/verify_resource.go
+++ b/pkg/k8smanifest/verify_resource.go
@@ -135,6 +135,7 @@ func VerifyResource(obj unstructured.Unstructured, vo *VerifyResourceOption) (*V
 		CertChain:  vo.CertificateChain,
 		RekorURL:   vo.RekorURL,
 		OIDCIssuer: vo.OIDCIssuer,
+		RootCerts:  vo.RootCerts,
 	}
 
 	var sigVerified bool

--- a/pkg/k8smanifest/verify_resource.go
+++ b/pkg/k8smanifest/verify_resource.go
@@ -130,9 +130,16 @@ func VerifyResource(obj unstructured.Unstructured, vo *VerifyResourceOption) (*V
 		signers = vo.Signers
 	}
 
+	cosignVerifyConfig := CosignVerifyConfig{
+		CertRef:    vo.Certificate,
+		CertChain:  vo.CertificateChain,
+		RekorURL:   vo.RekorURL,
+		OIDCIssuer: vo.OIDCIssuer,
+	}
+
 	var sigVerified bool
 	log.Debug("verifying signature...")
-	sigVerified, signerName, signedTimestamp, err = NewSignatureVerifier(objBytes, sigRef, keyPath, signers, vo.AnnotationConfig).Verify()
+	sigVerified, signerName, signedTimestamp, err = NewSignatureVerifier(objBytes, sigRef, keyPath, signers, cosignVerifyConfig, vo.AnnotationConfig).Verify()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to verify signature")
 	}


### PR DESCRIPTION
Signed-off-by: Hirokuni-Kitahara1 <hirokuni.kitahara1@ibm.com>

- `--rekor-url` option is added both for sign and verify command. (still environment variable `REKOR_SERVER` can be used.)
- `--certificate` and `--certificate-chain` are supported as same as cosign verify command.
- `--oidc-issuer` is supported for specifying fulcio OIDC issuer.