### PR TITLE
fix lint issue with the latest golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ kubectl-sigstore: build
 lint:
 	golangci-lint run
 
+.PHONY: lint-and-fix
+lint-and-fix:
+	golangci-lint run --fix
+
 .PHONY: test
 test:
 	@echo doing unit test

--- a/cmd/kubectl-sigstore/cli/apply_after_verify.go
+++ b/cmd/kubectl-sigstore/cli/apply_after_verify.go
@@ -18,7 +18,6 @@ package cli
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 
@@ -72,7 +71,7 @@ func NewCmdApplyAfterVerify() *cobra.Command {
 }
 
 func applyAfterVerify(filename, resBundleRef, keyPath, configPath string) error {
-	manifest, err := ioutil.ReadFile(filename)
+	manifest, err := os.ReadFile(filename)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		return nil

--- a/cmd/kubectl-sigstore/cli/manifest_build.go
+++ b/cmd/kubectl-sigstore/cli/manifest_build.go
@@ -19,7 +19,6 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -82,7 +81,7 @@ func buildManifest(baseDir, outputPath, provenancePath, resBundleRef, keyPath st
 		return errors.Wrap(err, "failed to execute kustomize build")
 	}
 	manifestFile := outputPath
-	err = ioutil.WriteFile(manifestFile, []byte(manifest), 0644)
+	err = os.WriteFile(manifestFile, []byte(manifest), 0644)
 	if err != nil {
 		return errors.Wrap(err, "failed to create a manifest file")
 	}
@@ -107,7 +106,7 @@ func buildManifest(baseDir, outputPath, provenancePath, resBundleRef, keyPath st
 		return errors.Wrap(err, "failed to marshal provenance")
 	}
 	provFile := provenancePath
-	err = ioutil.WriteFile(provFile, provBytes, 0644)
+	err = os.WriteFile(provFile, provBytes, 0644)
 	if err != nil {
 		return errors.Wrap(err, "failed to create a provenance file")
 	}
@@ -122,7 +121,7 @@ func buildManifest(baseDir, outputPath, provenancePath, resBundleRef, keyPath st
 			return errors.Wrap(err, "failed to marshal a rekor entry data")
 		}
 		rekorEntryFile := strings.TrimSuffix(provenancePath, ".json") + "-entry.json"
-		err = ioutil.WriteFile(rekorEntryFile, attestationBytes, 0644)
+		err = os.WriteFile(rekorEntryFile, attestationBytes, 0644)
 		if err != nil {
 			return errors.Wrap(err, "failed to create a rekor entry file")
 		}

--- a/cmd/kubectl-sigstore/cli/sign_test.go
+++ b/cmd/kubectl-sigstore/cli/sign_test.go
@@ -1,18 +1,16 @@
-//
 // Copyright 2021 The Sigstore Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 package cli
 
 import (

--- a/cmd/kubectl-sigstore/cli/sign_test.go
+++ b/cmd/kubectl-sigstore/cli/sign_test.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	_ "embed"
 	"encoding/base64"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -34,7 +33,7 @@ import (
 var b64EncodedTestKey []byte
 
 func TestSign(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "sign-test")
+	tmpDir, err := os.MkdirTemp("", "sign-test")
 	if err != nil {
 		t.Errorf("failed to create temp dir: %s", err.Error())
 		return
@@ -56,7 +55,7 @@ func TestSign(t *testing.T) {
 		t.Errorf("failed to sign the test file: %s", err.Error())
 		return
 	}
-	outBytes, err := ioutil.ReadFile(outPath)
+	outBytes, err := os.ReadFile(outPath)
 	if err != nil {
 		t.Errorf("failed to read the signed file: %s", err.Error())
 		return
@@ -70,7 +69,7 @@ func TestSign(t *testing.T) {
 		t.Errorf("failed to sign the test file: %s", err.Error())
 		return
 	}
-	outBytes2, err := ioutil.ReadFile(outPath2)
+	outBytes2, err := os.ReadFile(outPath2)
 	if err != nil {
 		t.Errorf("failed to read the signed file: %s", err.Error())
 		return
@@ -115,7 +114,7 @@ func initSingleTestFile(b64EncodedData []byte, fpath string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(fpath, testblob, 0644)
+	err = os.WriteFile(fpath, testblob, 0644)
 	if err != nil {
 		return err
 	}
@@ -123,7 +122,7 @@ func initSingleTestFile(b64EncodedData []byte, fpath string) error {
 }
 
 func getManifestInTarballMessage(msgBytes []byte) ([]byte, error) {
-	dir, err := ioutil.TempDir("", "kubectl-sigstore-sign-test-temp-dir")
+	dir, err := os.MkdirTemp("", "kubectl-sigstore-sign-test-temp-dir")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create temp directory")
 	}

--- a/cmd/kubectl-sigstore/cli/verify.go
+++ b/cmd/kubectl-sigstore/cli/verify.go
@@ -18,7 +18,6 @@ package cli
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 
@@ -68,7 +67,7 @@ func NewCmdVerify() *cobra.Command {
 }
 
 func verify(filename, resBundleRef, keyPath, configPath, certRef, certChain, rekorURL, oidcIssuer string) error {
-	manifest, err := ioutil.ReadFile(filename)
+	manifest, err := os.ReadFile(filename)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		return nil

--- a/cmd/kubectl-sigstore/cli/verify_resource.go
+++ b/cmd/kubectl-sigstore/cli/verify_resource.go
@@ -22,7 +22,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"reflect"
 	"runtime"
@@ -377,7 +377,7 @@ func verifyResource(yamls [][]byte, kubeGetArgs []string, resBundleRef, sigResRe
 
 func readManifestYAMLFile(fpath string) ([][]byte, error) {
 	var yamls [][]byte
-	content, err := ioutil.ReadFile(fpath)
+	content, err := os.ReadFile(fpath)
 	if err != nil {
 		return nil, err
 	}
@@ -386,7 +386,7 @@ func readManifestYAMLFile(fpath string) ([][]byte, error) {
 }
 
 func readStdinAsYAMLs() ([][]byte, error) {
-	stdinBytes, err := ioutil.ReadAll(os.Stdin)
+	stdinBytes, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubectl-sigstore/cli/verify_resource_test.go
+++ b/cmd/kubectl-sigstore/cli/verify_resource_test.go
@@ -21,7 +21,7 @@ import (
 	_ "embed"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -73,7 +73,7 @@ func createTestResource(fname string, namespace string) error {
 	var obj *unstructured.Unstructured
 	var err error
 
-	objBytes, err := ioutil.ReadFile(fname)
+	objBytes, err := os.ReadFile(fname)
 	if err != nil {
 		return errors.Wrap(err, "failed to read a testdata file")
 	}
@@ -159,7 +159,7 @@ var _ = BeforeSuite(func() {
 
 	kubeutil.SetKubeConfig(cfg)
 
-	testTempDir, err = ioutil.TempDir("", "verify-resource-test")
+	testTempDir, err = os.MkdirTemp("", "verify-resource-test")
 	Expect(err).NotTo(HaveOccurred())
 
 	kubeconfigBytes, err := testUser.KubeConfig()
@@ -167,7 +167,7 @@ var _ = BeforeSuite(func() {
 	fmt.Println(err)
 	Expect(err).NotTo(HaveOccurred())
 	kubeconfigPath := filepath.Join(testTempDir, "kubeconfig")
-	err = ioutil.WriteFile(kubeconfigPath, kubeconfigBytes, 0644)
+	err = os.WriteFile(kubeconfigPath, kubeconfigBytes, 0644)
 	Expect(err).NotTo(HaveOccurred())
 
 	KOptions.SetKubeConfig(kubeconfigPath, "default")
@@ -182,7 +182,7 @@ var _ = BeforeSuite(func() {
 
 	testpubBytes, err := base64.StdEncoding.DecodeString(string(b64EncodedTestPubKey))
 	Expect(err).ToNot(HaveOccurred())
-	err = ioutil.WriteFile(filepath.Join(testTempDir, "testpub"), testpubBytes, 0644)
+	err = os.WriteFile(filepath.Join(testTempDir, "testpub"), testpubBytes, 0644)
 	Expect(err).ToNot(HaveOccurred())
 
 }, 60)

--- a/example/admission-controller/pkg/config/config.go
+++ b/example/admission-controller/pkg/config/config.go
@@ -19,7 +19,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -109,7 +109,7 @@ func (c *ManifestIntegrityConfig) LoadKeySecret() (string, error) {
 	keyPath := ""
 	for fname, keyData := range secret.Data {
 		fpath := filepath.Join(keyDir, fname)
-		err := ioutil.WriteFile(fpath, keyData, 0644)
+		err := os.WriteFile(fpath, keyData, 0644)
 		if err != nil {
 			sumErr = append(sumErr, err.Error())
 			continue

--- a/example/verify-resource/sample.go
+++ b/example/verify-resource/sample.go
@@ -19,7 +19,7 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
@@ -90,7 +90,7 @@ func main() {
 }
 
 func (c *sandboxKubernetesCluster) initClientset() error {
-	cmBytes, err := ioutil.ReadFile(sampleCMYAMLPath)
+	cmBytes, err := os.ReadFile(sampleCMYAMLPath)
 	if err != nil {
 		return err
 	}

--- a/pkg/cosign/sign.go
+++ b/pkg/cosign/sign.go
@@ -23,7 +23,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -145,7 +144,7 @@ func SignBlob(blobPath string, keyPath, certPath *string, rekorURL string, pf co
 	regOpt := cliopt.RegistryOptions{}
 
 	m := map[string][]byte{}
-	rawMsg, err := ioutil.ReadFile(blobPath)
+	rawMsg, err := os.ReadFile(blobPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load a file to be signed")
 	}
@@ -179,7 +178,7 @@ func SignBlob(blobPath string, keyPath, certPath *string, rekorURL string, pf co
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get rekor client")
 		}
-		blobBytes, err := ioutil.ReadFile(blobPath)
+		blobBytes, err := os.ReadFile(blobPath)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to read blob file")
 		}
@@ -256,7 +255,7 @@ func SignBlob(blobPath string, keyPath, certPath *string, rekorURL string, pf co
 		}
 	} else if certPath != nil {
 		certPathStr := *certPath
-		certPem, err := ioutil.ReadFile(certPathStr)
+		certPem, err := os.ReadFile(certPathStr)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to load certificate at %s", certPathStr)
 		}

--- a/pkg/cosign/sign_test.go
+++ b/pkg/cosign/sign_test.go
@@ -1,18 +1,16 @@
-//
 // Copyright 2021 The Sigstore Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 package cosign
 
 import (

--- a/pkg/cosign/sign_test.go
+++ b/pkg/cosign/sign_test.go
@@ -16,7 +16,6 @@ package cosign
 import (
 	_ "embed"
 	"encoding/base64"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -42,7 +41,7 @@ type testFile struct {
 }
 
 func TestSignBlob(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "sign_test")
+	tmpDir, err := os.MkdirTemp("", "sign_test")
 	if err != nil {
 		t.Errorf("failed to create temp dir: %s", err.Error())
 		return
@@ -77,7 +76,7 @@ func TestSignBlob(t *testing.T) {
 
 	// b64SigBytes := sigMap["signature"]
 	// sigFileName := filepath.Join("testdata", "testsig")
-	// _ = ioutil.WriteFile(sigFileName, []byte(b64SigBytes), 0644)
+	// _ = os.WriteFile(sigFileName, []byte(b64SigBytes), 0644)
 }
 
 func passFuncForTest(b bool) ([]byte, error) {
@@ -99,7 +98,7 @@ func initSingleTestFile(b64EncodedData []byte, fpath string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(fpath, testblob, 0644)
+	err = os.WriteFile(fpath, testblob, 0644)
 	if err != nil {
 		return err
 	}

--- a/pkg/cosign/verify_test.go
+++ b/pkg/cosign/verify_test.go
@@ -1,18 +1,16 @@
-//
 // Copyright 2021 The Sigstore Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 package cosign
 
 import (

--- a/pkg/cosign/verify_test.go
+++ b/pkg/cosign/verify_test.go
@@ -15,14 +15,13 @@ package cosign
 
 import (
 	_ "embed"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
 func TestVerifyBlob(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "verify_test")
+	tmpDir, err := os.MkdirTemp("", "verify_test")
 	if err != nil {
 		t.Errorf("failed to create temp dir: %s", err.Error())
 		return

--- a/pkg/k8smanifest/opiton_test.go
+++ b/pkg/k8smanifest/opiton_test.go
@@ -1,18 +1,16 @@
-//
 // Copyright 2021 The Sigstore Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 package k8smanifest
 
 import (

--- a/pkg/k8smanifest/option.go
+++ b/pkg/k8smanifest/option.go
@@ -36,6 +36,7 @@ import (
 )
 
 // This is common ignore fields for changes by k8s system
+//
 //go:embed resources/default-config.yaml
 var defaultConfigBytes []byte
 

--- a/pkg/k8smanifest/sign.go
+++ b/pkg/k8smanifest/sign.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -181,7 +180,7 @@ func (s *ImageSigner) Sign(inputDir, output string, imageAnnotations map[string]
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to generate a signed YAML")
 		}
-		err = ioutil.WriteFile(output, signedBytes, 0644)
+		err = os.WriteFile(output, signedBytes, 0644)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to write a signed YAML into")
 		}
@@ -204,7 +203,7 @@ type BlobSigner struct {
 
 func (s *BlobSigner) Sign(inputDir, output string, imageAnnotations map[string]interface{}) ([]byte, error) {
 	var inputDataBuffer bytes.Buffer
-	dir, err := ioutil.TempDir("", "kubectl-sigstore-temp-dir")
+	dir, err := os.MkdirTemp("", "kubectl-sigstore-temp-dir")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create a temporary directory for signing")
 	}
@@ -230,7 +229,7 @@ func (s *BlobSigner) Sign(inputDir, output string, imageAnnotations map[string]i
 	}
 	var signedBytes []byte
 	var sigMaps map[string][]byte
-	err = ioutil.WriteFile(tmpBlobFile, inputDataBuffer.Bytes(), 0777)
+	err = os.WriteFile(tmpBlobFile, inputDataBuffer.Bytes(), 0777)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create a temporary blob file")
 	}
@@ -254,7 +253,7 @@ func (s *BlobSigner) Sign(inputDir, output string, imageAnnotations map[string]i
 				return nil, errors.Wrap(err, "failed to marshal a signature configmap")
 			}
 			sigResOutput := K8sResourceRef2FileName(output)
-			err = ioutil.WriteFile(sigResOutput, signedBytes, 0644)
+			err = os.WriteFile(sigResOutput, signedBytes, 0644)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to create a signature configmap YAML")
 			}
@@ -265,7 +264,7 @@ func (s *BlobSigner) Sign(inputDir, output string, imageAnnotations map[string]i
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to generate a signed YAML")
 		}
-		err = ioutil.WriteFile(output, signedBytes, 0644)
+		err = os.WriteFile(output, signedBytes, 0644)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to write a signed YAML into")
 		}
@@ -288,14 +287,14 @@ func makeMessageYAML(inputDir string, outBuffer *bytes.Buffer, moList ...*k8ssig
 }
 
 func uploadFileToRegistry(inputData []byte, resBundleRef string) error {
-	dir, err := ioutil.TempDir("", "kubectl-sigstore-temp-dir")
+	dir, err := os.MkdirTemp("", "kubectl-sigstore-temp-dir")
 	if err != nil {
 		return err
 	}
 	defer os.RemoveAll(dir)
 
 	fpath := filepath.Join(dir, "manifest.yaml")
-	err = ioutil.WriteFile(fpath, inputData, 0644)
+	err = os.WriteFile(fpath, inputData, 0644)
 	if err != nil {
 		return err
 	}

--- a/pkg/k8smanifest/sign_test.go
+++ b/pkg/k8smanifest/sign_test.go
@@ -1,18 +1,16 @@
-//
 // Copyright 2021 The Sigstore Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 package k8smanifest
 
 import (

--- a/pkg/k8smanifest/sign_test.go
+++ b/pkg/k8smanifest/sign_test.go
@@ -16,7 +16,6 @@ package k8smanifest
 import (
 	_ "embed"
 	"encoding/base64"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -31,7 +30,7 @@ import (
 var b64EncodedTestKey []byte
 
 func TestSign(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "k8smanifest-sign-test")
+	tmpDir, err := os.MkdirTemp("", "k8smanifest-sign-test")
 	if err != nil {
 		t.Errorf("failed to create temp dir: %s", err.Error())
 		return
@@ -112,7 +111,7 @@ func TestSign(t *testing.T) {
 }
 
 func TestNonTarballSign(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "k8smanifest-sign-test")
+	tmpDir, err := os.MkdirTemp("", "k8smanifest-sign-test")
 	if err != nil {
 		t.Errorf("failed to create temp dir: %s", err.Error())
 		return
@@ -151,7 +150,7 @@ func initSingleTestFile(b64EncodedData []byte, fpath string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(fpath, testblob, 0644)
+	err = os.WriteFile(fpath, testblob, 0644)
 	if err != nil {
 		return err
 	}

--- a/pkg/k8smanifest/verify_resource.go
+++ b/pkg/k8smanifest/verify_resource.go
@@ -473,7 +473,8 @@ func inclusionMatch(messageYAMLBytes, resourceJSONBytes, dryRunBytes []byte, clu
 // remove a diff result caused by image canonicalization
 // diffs like below can be ignored, so remove them from the result
 // e.g.) nginx:1.14.2 --> docker.io/nginx:1.14.2
-//       ubuntu --> ubuntu:latest
+//
+//	ubuntu --> ubuntu:latest
 func removeCanonicalizedImageDiff(diff *mapnode.DiffResult) *mapnode.DiffResult {
 	if diff == nil || diff.Size() == 0 {
 		return nil

--- a/pkg/k8smanifest/verify_test.go
+++ b/pkg/k8smanifest/verify_test.go
@@ -17,7 +17,6 @@ import (
 	_ "embed"
 	"encoding/base64"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -34,7 +33,7 @@ var b64EncodedTestPubkey []byte
 const b64KeylesSignerConfig = "aGlyb2t1bmkua2l0YWhhcmExQGlibS5jb20K"
 
 func TestVerifyResource(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "k8smanifest-verify-resource-test")
+	tmpDir, err := os.MkdirTemp("", "k8smanifest-verify-resource-test")
 	if err != nil {
 		t.Errorf("failed to create temp dir: %s", err.Error())
 		return
@@ -49,7 +48,7 @@ func TestVerifyResource(t *testing.T) {
 	}
 
 	fpath := "testdata/sample-configmap-signed.yaml"
-	objBytes, err := ioutil.ReadFile(fpath)
+	objBytes, err := os.ReadFile(fpath)
 	if err != nil {
 		t.Errorf("failed to load a test resource file: %s", err.Error())
 		return
@@ -77,7 +76,7 @@ func TestVerifyResource(t *testing.T) {
 }
 
 func TestVerifyResourceWithoutMessageAndSignature(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "k8smanifest-verify-resource-test")
+	tmpDir, err := os.MkdirTemp("", "k8smanifest-verify-resource-test")
 	if err != nil {
 		t.Errorf("failed to create temp dir: %s", err.Error())
 		return
@@ -92,7 +91,7 @@ func TestVerifyResourceWithoutMessageAndSignature(t *testing.T) {
 	}
 
 	fpath := "testdata/sample-configmap-signed.yaml"
-	objBytes, err := ioutil.ReadFile(fpath)
+	objBytes, err := os.ReadFile(fpath)
 	if err != nil {
 		t.Errorf("failed to load a test resource file: %s", err.Error())
 		return
@@ -136,7 +135,7 @@ func TestVerifyResourceWithoutMessageAndSignature(t *testing.T) {
 }
 
 func TestVerifyResourceWithMultipleSignatures(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "k8smanifest-verify-resource-multisig-test")
+	tmpDir, err := os.MkdirTemp("", "k8smanifest-verify-resource-multisig-test")
 	if err != nil {
 		t.Errorf("failed to create temp dir: %s", err.Error())
 		return
@@ -151,7 +150,7 @@ func TestVerifyResourceWithMultipleSignatures(t *testing.T) {
 	}
 
 	fpath := "testdata/sample-configmap-multi-signed.yaml"
-	objBytes, err := ioutil.ReadFile(fpath)
+	objBytes, err := os.ReadFile(fpath)
 	if err != nil {
 		t.Errorf("failed to load a test resource file: %s", err.Error())
 		return
@@ -179,7 +178,7 @@ func TestVerifyResourceWithMultipleSignatures(t *testing.T) {
 }
 
 func TestVerifyResourceWithKeylessMultipleSignatures(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "k8smanifest-verify-resource-keyless-multisig-test")
+	tmpDir, err := os.MkdirTemp("", "k8smanifest-verify-resource-keyless-multisig-test")
 	if err != nil {
 		t.Errorf("failed to create temp dir: %s", err.Error())
 		return
@@ -194,7 +193,7 @@ func TestVerifyResourceWithKeylessMultipleSignatures(t *testing.T) {
 	}
 
 	fpath := "testdata/sample-configmap-keyless-multi-signed.yaml"
-	objBytes, err := ioutil.ReadFile(fpath)
+	objBytes, err := os.ReadFile(fpath)
 	if err != nil {
 		t.Errorf("failed to load a test resource file: %s", err.Error())
 		return
@@ -230,7 +229,7 @@ func TestVerifyResourceWithKeylessMultipleSignatures(t *testing.T) {
 }
 
 func TestVerifyResourceWithoutDryRun(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "k8smanifest-verify-resource-without-dryrun-test")
+	tmpDir, err := os.MkdirTemp("", "k8smanifest-verify-resource-without-dryrun-test")
 	if err != nil {
 		t.Errorf("failed to create temp dir: %s", err.Error())
 		return
@@ -245,7 +244,7 @@ func TestVerifyResourceWithoutDryRun(t *testing.T) {
 	}
 
 	fpath := "testdata/sample-deployment-signed-deployed.yaml"
-	objBytes, err := ioutil.ReadFile(fpath)
+	objBytes, err := os.ReadFile(fpath)
 	if err != nil {
 		t.Errorf("failed to load a test resource file: %s", err.Error())
 		return
@@ -280,7 +279,7 @@ func TestVerifyResourceWithoutDryRun(t *testing.T) {
 }
 
 func TestInclusionMatch(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "k8smanifest-verify-resource-test")
+	tmpDir, err := os.MkdirTemp("", "k8smanifest-verify-resource-test")
 	if err != nil {
 		t.Errorf("failed to create temp dir: %s", err.Error())
 		return
@@ -295,14 +294,14 @@ func TestInclusionMatch(t *testing.T) {
 	}
 
 	f1path := "testdata/sample-deployment-signed.yaml"
-	mnfBytes, err := ioutil.ReadFile(f1path)
+	mnfBytes, err := os.ReadFile(f1path)
 	if err != nil {
 		t.Errorf("failed to load a test resource file for manifest: %s", err.Error())
 		return
 	}
 
 	f2path := "testdata/sample-deployment-signed-mutating-1.yaml"
-	objYAMLBytes, err := ioutil.ReadFile(f2path)
+	objYAMLBytes, err := os.ReadFile(f2path)
 	if err != nil {
 		t.Errorf("failed to load a test resource file for obejct: %s", err.Error())
 		return
@@ -314,7 +313,7 @@ func TestInclusionMatch(t *testing.T) {
 	}
 
 	f3path := "testdata/sample-deployment-signed-mutating-2.yaml"
-	dyrRunBytes, err := ioutil.ReadFile(f3path)
+	dyrRunBytes, err := os.ReadFile(f3path)
 	if err != nil {
 		t.Errorf("failed to load a test resource file for DryRun result: %s", err.Error())
 		return

--- a/pkg/k8smanifest/verify_test.go
+++ b/pkg/k8smanifest/verify_test.go
@@ -1,18 +1,16 @@
-//
 // Copyright 2021 The Sigstore Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 package k8smanifest
 
 import (

--- a/pkg/util/cache.go
+++ b/pkg/util/cache.go
@@ -210,7 +210,11 @@ func (c *LocalFileCache) clearExpiredData() error {
 			continue
 		} else {
 			fname := path.Join(c.baseDir, fd.Name())
-			modTime := fd.ModTime().UTC()
+			fi, err := fd.Info()
+			if err != nil {
+				return err
+			}
+			modTime := fi.ModTime().UTC()
 			now := time.Now().UTC()
 			if now.Sub(modTime) > c.TTL {
 				err = os.Remove(fname)

--- a/pkg/util/cache.go
+++ b/pkg/util/cache.go
@@ -21,7 +21,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -135,7 +135,7 @@ func (c *LocalFileCache) Set(key string, value ...interface{}) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(fpath, valueBytes, 0644)
+	err = os.WriteFile(fpath, valueBytes, 0644)
 	if err != nil {
 		return err
 	}
@@ -157,7 +157,7 @@ func (c *LocalFileCache) Get(key string) ([]interface{}, error) {
 	}
 
 	fpath := c.genFileNameFromKey(key)
-	valueBytes, err := ioutil.ReadFile(fpath)
+	valueBytes, err := os.ReadFile(fpath)
 	if err != nil {
 		return nil, err
 	}
@@ -201,8 +201,8 @@ func (c *LocalFileCache) clearExpiredData() error {
 	c.mem.clearExpiredData()
 
 	var err error
-	var fds []os.FileInfo
-	if fds, err = ioutil.ReadDir(c.baseDir); err != nil {
+	var fds []fs.DirEntry
+	if fds, err = os.ReadDir(c.baseDir); err != nil {
 		return err
 	}
 	for _, fd := range fds {

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -23,7 +23,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -52,7 +52,7 @@ func TarGzCompress(src string, buf io.Writer, moList ...*MutateOptions) error {
 
 	var errV error
 
-	// we cannot use ioutil.TempDir() here because it creates a direcotry with a different name everytime
+	// we cannot use os.MkdirTemp() here because it creates a direcotry with a different name everytime
 	// it results in inconsistent compression result that means inconsistent message even for the identical input.
 	// instead, we use a temporary directory which is named like `compression-tar-gz-<INPUT_FILE_DIGEST>`.
 	digest, err := getSourceDigest(src, moList)
@@ -246,7 +246,7 @@ func TarGzDecompress(src io.Reader, dst string) error {
 // copy an entire directory recursively
 func copyDir(src string, dst string) error {
 	var err error
-	var fds []os.FileInfo
+	var fds []fs.DirEntry
 	var srcinfo os.FileInfo
 
 	if srcinfo, err = os.Stat(src); err != nil {
@@ -258,7 +258,7 @@ func copyDir(src string, dst string) error {
 			return err
 		}
 
-		if fds, err = ioutil.ReadDir(src); err != nil {
+		if fds, err = os.ReadDir(src); err != nil {
 			return err
 		}
 		for _, fd := range fds {
@@ -291,12 +291,12 @@ func copyFile(src string, dst string) error {
 		return err
 	}
 
-	input, err := ioutil.ReadFile(src)
+	input, err := os.ReadFile(src)
 	if err != nil {
 		return err
 	}
 
-	err = ioutil.WriteFile(dst, input, fi.Mode())
+	err = os.WriteFile(dst, input, fi.Mode())
 	if err != nil {
 		return err
 	}

--- a/pkg/util/gzip.go
+++ b/pkg/util/gzip.go
@@ -19,7 +19,7 @@ package util
 import (
 	"bytes"
 	"compress/gzip"
-	"io/ioutil"
+	"io"
 )
 
 func GzipCompress(in []byte) []byte {
@@ -36,7 +36,7 @@ func GzipDecompress(in []byte) []byte {
 	if err != nil {
 		return in
 	}
-	out, err := ioutil.ReadAll(gzreader)
+	out, err := io.ReadAll(gzreader)
 	if err != nil {
 		return in
 	}

--- a/pkg/util/image.go
+++ b/pkg/util/image.go
@@ -22,7 +22,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -70,7 +69,7 @@ func GetBlob(layer v1.Layer) ([]byte, error) {
 		return nil, errors.Wrap(err, "failed to get blob in image")
 	}
 	defer rc.Close()
-	return ioutil.ReadAll(rc)
+	return io.ReadAll(rc)
 }
 
 func GenerateConcatYAMLsFromImage(img v1.Image) ([]byte, error) {

--- a/pkg/util/kubeutil/dryrun_test.go
+++ b/pkg/util/kubeutil/dryrun_test.go
@@ -17,7 +17,7 @@
 package kubeutil
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/ghodss/yaml"
@@ -87,7 +87,7 @@ var _ = Describe("Test Kubeutil Functions", func() {
 	It("DryRunCreate Test", func() {
 		var timeout int = 10
 		Eventually(func() error {
-			testObj, err := ioutil.ReadFile("testdata/sample_configmap.yaml")
+			testObj, err := os.ReadFile("testdata/sample_configmap.yaml")
 			if err != nil {
 				return err
 			}
@@ -101,7 +101,7 @@ var _ = Describe("Test Kubeutil Functions", func() {
 	It("StrategicMergePatch Test", func() {
 		var timeout int = 10
 		Eventually(func() error {
-			testObj, err := ioutil.ReadFile("testdata/sample_configmap.yaml")
+			testObj, err := os.ReadFile("testdata/sample_configmap.yaml")
 			if err != nil {
 				return err
 			}
@@ -109,7 +109,7 @@ var _ = Describe("Test Kubeutil Functions", func() {
 			if err != nil {
 				return err
 			}
-			testObjOrg, err := ioutil.ReadFile("testdata/sample_configmap_after.yaml")
+			testObjOrg, err := os.ReadFile("testdata/sample_configmap_after.yaml")
 			if err != nil {
 				return err
 			}
@@ -123,7 +123,7 @@ var _ = Describe("Test Kubeutil Functions", func() {
 	It("GetApplyPatchBytes Test", func() {
 		var timeout int = 20
 		Eventually(func() error {
-			testObj, err := ioutil.ReadFile("testdata/sample_configmap_after.yaml")
+			testObj, err := os.ReadFile("testdata/sample_configmap_after.yaml")
 			if err != nil {
 				return err
 			}

--- a/pkg/util/kubeutil/kubeutil_test.go
+++ b/pkg/util/kubeutil/kubeutil_test.go
@@ -17,7 +17,7 @@
 package kubeutil
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/ghodss/yaml"
@@ -42,7 +42,7 @@ func TestKubeConfig(t *testing.T) {
 }
 
 func TestMatchLabels(t *testing.T) {
-	testCmBytes, err := ioutil.ReadFile("testdata/sample_configmap.yaml")
+	testCmBytes, err := os.ReadFile("testdata/sample_configmap.yaml")
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/util/manifestbuild/kustomize/kustomize.go
+++ b/pkg/util/manifestbuild/kustomize/kustomize.go
@@ -21,7 +21,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -82,7 +81,7 @@ func LoadKustomization(fpath, baseDir, gitURL, gitRevision string, inRemoteRepo 
 	if !FileExists(fpath) {
 		return nil, fmt.Errorf("%s does not exists", fpath)
 	}
-	data, err := ioutil.ReadFile(fpath)
+	data, err := os.ReadFile(fpath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read %s", fpath)
 	}

--- a/pkg/util/manifestbuild/kustomize/provenance.go
+++ b/pkg/util/manifestbuild/kustomize/provenance.go
@@ -129,7 +129,8 @@ func GenerateAttestation(provPath, privKeyPath string) (*dsse.Envelope, error) {
 
 // get a digest of artifact by checking artifact type
 // when the artifact is local file --> sha256 file hash
-//                   is OCI image --> image digest
+//
+//	is OCI image --> image digest
 func GetDigestOfArtifact(artifactPath string) (string, error) {
 	var digest string
 	var err error

--- a/pkg/util/mapnode/node_test.go
+++ b/pkg/util/mapnode/node_test.go
@@ -1,4 +1,3 @@
-//
 // Copyright 2020 IBM Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 package mapnode
 
 import (

--- a/pkg/util/mapnode/node_test.go
+++ b/pkg/util/mapnode/node_test.go
@@ -15,16 +15,16 @@ package mapnode
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 )
 
 func TestNode(t *testing.T) {
 
-	testMapBytes, _ := ioutil.ReadFile("testdata/data1.json")
-	testMap2Bytes, _ := ioutil.ReadFile("testdata/data2.json")
-	testMap4Bytes, _ := ioutil.ReadFile("testdata/data3.json")
-	deployOperatorBytes, _ := ioutil.ReadFile("testdata/data4.json")
+	testMapBytes, _ := os.ReadFile("testdata/data1.json")
+	testMap2Bytes, _ := os.ReadFile("testdata/data2.json")
+	testMap4Bytes, _ := os.ReadFile("testdata/data3.json")
+	deployOperatorBytes, _ := os.ReadFile("testdata/data4.json")
 
 	mergeTestByte := []byte(`{"metadata":{"name":"test-resource"}}`)
 	mergeTestByte2 := []byte(`{"metadata":{"namespace":"test-ns"}}`)

--- a/pkg/util/sigtypes/x509/x509.go
+++ b/pkg/util/sigtypes/x509/x509.go
@@ -25,7 +25,7 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -131,7 +131,7 @@ func LoadCertificate(certPath string) (*x509.Certificate, error) {
 		certPemBytes = tmpCertBytes
 	} else {
 		cpath := filepath.Clean(certPath)
-		certPemBytes, err = ioutil.ReadFile(cpath)
+		certPemBytes, err = os.ReadFile(cpath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read a cert file; %s", err.Error())
 		}
@@ -176,7 +176,7 @@ func LoadCertificateChain(certChainPath string) ([]*x509.Certificate, error) {
 		certPemBytes = tmpCertBytes
 	} else {
 		cpath := filepath.Clean(certChainPath)
-		certPemBytes, err = ioutil.ReadFile(cpath)
+		certPemBytes, err = os.ReadFile(cpath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read a cert file; %s", err.Error())
 		}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,18 +1,16 @@
-//
 // Copyright 2021 The Sigstore Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 package util
 
 import (

--- a/pkg/util/yaml.go
+++ b/pkg/util/yaml.go
@@ -19,7 +19,6 @@ package util
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -67,7 +66,7 @@ func FindYAMLsInDir(dirPath string) ([][]byte, error) {
 	foundYAMLs := [][]byte{}
 	err := filepath.Walk(dirPath, func(fpath string, info os.FileInfo, err error) error {
 		if err == nil && supportedExtensions[path.Ext(info.Name())] {
-			yamlBytes, err := ioutil.ReadFile(fpath)
+			yamlBytes, err := os.ReadFile(fpath)
 			if err == nil && isK8sResourceYAML(yamlBytes) {
 				foundYAMLs = append(foundYAMLs, yamlBytes)
 			}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -25,7 +25,6 @@ import (
 	_ "embed"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -109,7 +108,7 @@ var _ = BeforeSuite(func() {
 
 	kubeutil.SetKubeConfig(cfg)
 
-	testTempDir, err = ioutil.TempDir("", "k8s-manifest-sigstore-e2e-test")
+	testTempDir, err = os.MkdirTemp("", "k8s-manifest-sigstore-e2e-test")
 	Expect(err).NotTo(HaveOccurred())
 
 	kubeconfigBytes, err := testUser.KubeConfig()
@@ -117,7 +116,7 @@ var _ = BeforeSuite(func() {
 	fmt.Println(err)
 	Expect(err).NotTo(HaveOccurred())
 	kubeconfigPath := filepath.Join(testTempDir, "kubeconfig")
-	err = ioutil.WriteFile(kubeconfigPath, kubeconfigBytes, 0644)
+	err = os.WriteFile(kubeconfigPath, kubeconfigBytes, 0644)
 	Expect(err).NotTo(HaveOccurred())
 
 	cli.KOptions.SetKubeConfig(kubeconfigPath, "default")
@@ -322,7 +321,7 @@ func setup(keyPath, pubkeyPath string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(keyPath, testkeyBytes, 0644)
+	err = os.WriteFile(keyPath, testkeyBytes, 0644)
 	if err != nil {
 		return err
 	}
@@ -331,7 +330,7 @@ func setup(keyPath, pubkeyPath string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(pubkeyPath, testPubkeyBytes, 0644)
+	err = os.WriteFile(pubkeyPath, testPubkeyBytes, 0644)
 	if err != nil {
 		return err
 	}
@@ -401,7 +400,7 @@ func createTestResource(fname string, namespace string) error {
 	var obj *unstructured.Unstructured
 	var err error
 
-	objBytes, err := ioutil.ReadFile(fname)
+	objBytes, err := os.ReadFile(fname)
 	if err != nil {
 		return errors.Wrap(err, "failed to read a testdata file")
 	}
@@ -463,7 +462,7 @@ func createTestResource(fname string, namespace string) error {
 
 func loadObjYAML(fname string) (*unstructured.Unstructured, error) {
 	var obj *unstructured.Unstructured
-	objBytes, err := ioutil.ReadFile(fname)
+	objBytes, err := os.ReadFile(fname)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Hirokuni-Kitahara1 <hirokuni.kitahara1@ibm.com>

- fix lint issues with the latest version of `golangci-lint` 
- `io/ioutil` is deprecated since go v1.16, and now `golangci-lint` reports error if the code uses it. update codes for that.