### PR TITLE
bump cosign to v1.12.1 for releasing v0.4.1

### DIFF
--- a/cmd/kubectl-sigstore/cli/sign_test.go
+++ b/cmd/kubectl-sigstore/cli/sign_test.go
@@ -50,7 +50,7 @@ func TestSign(t *testing.T) {
 
 	fpath := "testdata/sample-configmap.yaml"
 	outPath := filepath.Join(tmpDir, "sample-configmap.yaml.signed")
-	err = sign(fpath, "", keyPath, "", outPath, false, false, true, true, false, nil)
+	err = sign(fpath, "", keyPath, "", outPath, false, false, true, true, false, false, false, nil)
 	if err != nil {
 		t.Errorf("failed to sign the test file: %s", err.Error())
 		return
@@ -64,7 +64,7 @@ func TestSign(t *testing.T) {
 
 	fpath2 := "testdata/sample-configmap-concat.yaml"
 	outPath2 := filepath.Join(tmpDir, "sample-configmap-concat.yaml.signed")
-	err = sign(fpath2, "", keyPath, "", outPath2, false, false, true, true, false, nil)
+	err = sign(fpath2, "", keyPath, "", outPath2, false, false, true, true, false, false, false, nil)
 	if err != nil {
 		t.Errorf("failed to sign the test file: %s", err.Error())
 		return

--- a/cmd/kubectl-sigstore/cli/verify_resource_test.go
+++ b/cmd/kubectl-sigstore/cli/verify_resource_test.go
@@ -207,7 +207,7 @@ var _ = Describe("Test Kubeutil Sigstore Functions", func() {
 				return err
 			}
 
-			verified, err := verifyResource(nil, []string{"cm", "sample-cm"}, "", "", "", "", "", "", false, false, "", "", "", "", "", "", 4)
+			verified, err := verifyResource(nil, []string{"cm", "sample-cm"}, "", "", "", "", "", "", false, false, false, "", "", "", "", "", "", 4)
 			if err != nil {
 				return err
 			}
@@ -227,7 +227,7 @@ var _ = Describe("Test Kubeutil Sigstore Functions", func() {
 			}
 
 			pubkeyPath := filepath.Join(testTempDir, "testpub")
-			verified, err := verifyResource(nil, []string{"cm", "sample-cm-signed"}, "", "", pubkeyPath, "", "", "", false, false, "", "", "", "", "", "json", 4)
+			verified, err := verifyResource(nil, []string{"cm", "sample-cm-signed"}, "", "", pubkeyPath, "", "", "", false, false, false, "", "", "", "", "", "json", 4)
 			if err != nil {
 				return err
 			}

--- a/docs/LATEST_RELEASE.md
+++ b/docs/LATEST_RELEASE.md
@@ -1,3 +1,56 @@
+
+# What's new in v0.4.1
+
+In this release, we updated cosign version to v1.12.1 and added some CLI options as well as cosign.
+
+## Add `--allow-insecure-registry` for sign/verify commands
+
+Using cosign v1.12.0 and later, an insecure container registry must be accessed intentionally with `--allow-insecure-registry` option.
+
+We have added the same CLi option to sign/verify command in this project too.
+
+(Note: If you use images on ghcr.io, basically need to specify this option.)
+
+## Add `--force` for sign command
+
+Now cosign has `--force` option for sign command, and we have added it to this project too.
+
+If you want to skip some validations/checks using interactive CLI input while cosign signing, this option works for it.
+
+It is also used when the signing steps are automated and when you cannot input anything while the signing.
+
+---
+
+# Backlog 
+
+---
+
+What's new in v0.4.0
+
+In this release, a new signing method is added to `kubectl sigstore sign` command. It is not a default signing option yet, but we are planning the method will be default on the release v0.5.0 and later. The detail is described below.
+
+## Add a new signing method and the original signing method will be non-default soon
+
+The original signing method (`--tarball=yes`) creates a tarball of YAML files before signing.
+
+However, this may cause verification error when multiple signatures are provided.
+
+So we have added a new signing method (`--tarball=no`) that can solve this issue.
+
+The original method is still the default option now, but the new one will be default on v0.5.0 and later.
+
+## Support multiple signatures both for signing & verification
+
+A new signing option `--append-signature` (or `-A`) has been added for users to generate a signed YAML manifest that have multiple signatures.
+
+Users don't need to manually add them anymore.
+
+## Update cosign version to v1.10.1
+
+We updated the version of cosign on which k8s-manifest-sigstore depends, and added some new command options to be consistent with cosign
+
+---
+
 # What's new in v0.3.0
 
 In this release, we mainly updated verification functions so that users can easily & flexibly use `k8s-manifest-sigstore`.
@@ -76,9 +129,7 @@ The following 2 options are added as verify-resource options to enable flexible 
 
 The dependency version of cosign is updated to v1.8.0.
 
----
 
-# Backlog 
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/spf13/cobra v1.5.0
 	github.com/tektoncd/chains v0.3.0
 	github.com/theupdateframework/go-tuf v0.5.0
+	github.com/transparency-dev/merkle v0.0.1
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.23.5
@@ -234,7 +235,6 @@ require (
 	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 // indirect
 	github.com/tjfoc/gmsm v1.3.2 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 // indirect
-	github.com/transparency-dev/merkle v0.0.1 // indirect
 	github.com/urfave/cli v1.22.7 // indirect
 	github.com/vbatts/tar-split v0.11.2 // indirect
 	github.com/xanzy/go-gitlab v0.73.1 // indirect

--- a/pkg/cosign/sign_test.go
+++ b/pkg/cosign/sign_test.go
@@ -60,7 +60,7 @@ func TestSignBlob(t *testing.T) {
 	blobPath := files["blob"].fpath
 	keyPath := files["key"].fpath
 
-	sigMap, err := SignBlob(blobPath, &keyPath, nil, "", false, passFuncForTest)
+	sigMap, err := SignBlob(blobPath, &keyPath, nil, "", false, false, passFuncForTest)
 	if err != nil {
 		t.Errorf("failed to load test files: %s", err.Error())
 		return

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -47,7 +47,7 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature/payload"
 )
 
-func VerifyImage(resBundleRef, pubkeyPath, certRef, certChain, rekorURL, oidcIssuer string, rootCerts *x509.CertPool) (bool, string, *int64, error) {
+func VerifyImage(resBundleRef, pubkeyPath, certRef, certChain, rekorURL, oidcIssuer string, rootCerts *x509.CertPool, allowInsecure bool) (bool, string, *int64, error) {
 	ref, err := name.ParseReference(resBundleRef)
 	if err != nil {
 		return false, "", nil, fmt.Errorf("failed to parse image ref `%s`; %s", resBundleRef, err.Error())
@@ -61,6 +61,9 @@ func VerifyImage(resBundleRef, pubkeyPath, certRef, certChain, rekorURL, oidcIss
 	}
 
 	regOpt := &cliopt.RegistryOptions{}
+	if allowInsecure {
+		regOpt.AllowInsecure = true
+	}
 	reqCliOpt, err := regOpt.ClientOpts(context.Background())
 	if err != nil {
 		return false, "", nil, fmt.Errorf("failed to get registry client option; %s", err.Error())

--- a/pkg/k8smanifest/option.go
+++ b/pkg/k8smanifest/option.go
@@ -131,8 +131,10 @@ type commonOption struct {
 
 // cosign sign option
 type cosignSignOption struct {
-	RekorURL     string `json:"-"`
-	NoTlogUpload bool   `json:"-"`
+	RekorURL      string `json:"-"`
+	NoTlogUpload  bool   `json:"-"`
+	AllowInsecure bool   `json:"-"`
+	Force         bool   `json:"-"`
 }
 
 // cosign verify option
@@ -142,6 +144,7 @@ type cosignVerifyOption struct {
 	RekorURL         string         `json:"-"`
 	OIDCIssuer       string         `json:"-"`
 	RootCerts        *x509.CertPool `json:"-"`
+	AllowInsecure    bool           `json:"-"`
 }
 
 // annotation config for signing and verification

--- a/pkg/k8smanifest/verify_manifest.go
+++ b/pkg/k8smanifest/verify_manifest.go
@@ -61,7 +61,7 @@ func VerifyManifest(objManifest []byte, vo *VerifyManifestOption) (*VerifyResult
 
 	var resourceManifests [][]byte
 	var sigRef string
-	resourceManifests, sigRef, err = NewManifestFetcher(vo.ResourceBundleRef, vo.SignatureResourceRef, vo.AnnotationConfig, ignoreFields, vo.MaxResourceManifestNum).Fetch(objManifest)
+	resourceManifests, sigRef, err = NewManifestFetcher(vo.ResourceBundleRef, vo.SignatureResourceRef, vo.AnnotationConfig, ignoreFields, vo.MaxResourceManifestNum, vo.AllowInsecure).Fetch(objManifest)
 	if err != nil {
 		return nil, errors.Wrap(err, "reference YAML manifest not found for this manifest")
 	}
@@ -95,11 +95,12 @@ func VerifyManifest(objManifest []byte, vo *VerifyManifestOption) (*VerifyResult
 	}
 
 	cosignVerifyConfig := CosignVerifyConfig{
-		CertRef:    vo.Certificate,
-		CertChain:  vo.CertificateChain,
-		RekorURL:   vo.RekorURL,
-		OIDCIssuer: vo.OIDCIssuer,
-		RootCerts:  vo.RootCerts,
+		CertRef:       vo.Certificate,
+		CertChain:     vo.CertificateChain,
+		RekorURL:      vo.RekorURL,
+		OIDCIssuer:    vo.OIDCIssuer,
+		RootCerts:     vo.RootCerts,
+		AllowInsecure: vo.AllowInsecure,
 	}
 
 	sigVerified, signerName, _, err := NewSignatureVerifier(objManifest, sigRef, keyPath, signers, cosignVerifyConfig, vo.AnnotationConfig).Verify()

--- a/pkg/k8smanifest/verify_resource.go
+++ b/pkg/k8smanifest/verify_resource.go
@@ -97,7 +97,7 @@ func VerifyResource(obj unstructured.Unstructured, vo *VerifyResourceOption) (*V
 
 	var resourceManifests [][]byte
 	log.Debug("fetching manifest...")
-	resourceManifests, sigRef, err = NewManifestFetcher(vo.ResourceBundleRef, sigResourceRefString, vo.AnnotationConfig, ignoreFields, vo.MaxResourceManifestNum).Fetch(objBytes)
+	resourceManifests, sigRef, err = NewManifestFetcher(vo.ResourceBundleRef, sigResourceRefString, vo.AnnotationConfig, ignoreFields, vo.MaxResourceManifestNum, vo.AllowInsecure).Fetch(objBytes)
 	if err != nil {
 		retErr := errors.Wrap(err, "YAML manifest not found for this resource")
 		log.Debugf("IsMessageNotFoundError(): %v", IsMessageNotFoundError(retErr))
@@ -133,11 +133,12 @@ func VerifyResource(obj unstructured.Unstructured, vo *VerifyResourceOption) (*V
 	}
 
 	cosignVerifyConfig := CosignVerifyConfig{
-		CertRef:    vo.Certificate,
-		CertChain:  vo.CertificateChain,
-		RekorURL:   vo.RekorURL,
-		OIDCIssuer: vo.OIDCIssuer,
-		RootCerts:  vo.RootCerts,
+		CertRef:       vo.Certificate,
+		CertChain:     vo.CertificateChain,
+		RekorURL:      vo.RekorURL,
+		OIDCIssuer:    vo.OIDCIssuer,
+		RootCerts:     vo.RootCerts,
+		AllowInsecure: vo.AllowInsecure,
 	}
 
 	var sigVerified bool
@@ -156,7 +157,7 @@ func VerifyResource(obj unstructured.Unstructured, vo *VerifyResourceOption) (*V
 
 	provenances := []*Provenance{}
 	if vo.Provenance {
-		provenances, err = NewProvenanceGetter(&obj, sigRef, "", vo.ProvenanceResourceRef).Get()
+		provenances, err = NewProvenanceGetter(&obj, sigRef, "", vo.ProvenanceResourceRef, vo.AllowInsecure).Get()
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get provenance")
 		}

--- a/pkg/util/image.go
+++ b/pkg/util/image.go
@@ -20,6 +20,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -27,32 +28,42 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/pkg/errors"
+	cliopt "github.com/sigstore/cosign/cmd/cosign/cli/options"
 	"github.com/spf13/afero"
 )
 
-func PullImage(resBundleRef string) (v1.Image, error) {
+func PullImage(resBundleRef string, allowInsecure bool) (v1.Image, error) {
 	ref, err := name.ParseReference(resBundleRef)
 	if err != nil {
 		return nil, err
 	}
-	img, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	regOpt := cliopt.RegistryOptions{}
+	if allowInsecure {
+		regOpt.AllowInsecure = true
+	}
+	reqCliOpt := regOpt.GetRegistryClientOpts(context.Background())
+	img, err := remote.Image(ref, reqCliOpt...)
 	if err != nil {
 		return nil, err
 	}
 	return img, nil
 }
 
-func GetImageDigest(resBundleRef string) (string, error) {
+func GetImageDigest(resBundleRef string, allowInsecure bool) (string, error) {
 	ref, err := name.ParseReference(resBundleRef)
 	if err != nil {
 		return "", err
 	}
-	img, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	regOpt := cliopt.RegistryOptions{}
+	if allowInsecure {
+		regOpt.AllowInsecure = true
+	}
+	reqCliOpt := regOpt.GetRegistryClientOpts(context.Background())
+	img, err := remote.Image(ref, reqCliOpt...)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Signed-off-by: Hirokuni-Kitahara1 <hirokuni.kitahara1@ibm.com>

The main update in v0.4.1 release is updating cosign version to v1.12.1.
- add 2 CLI options that have been added by cosign v1.12.1.
- update release note doc