### PR TITLE
Add scorecard analysis tool

### DIFF
--- a/.github/scorecard.yml
+++ b/.github/scorecard.yml
@@ -1,0 +1,31 @@
+name: Scorecard supply-chain security
+on:
+  # (Optional) For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  # branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: '32 18 * * 0'
+  push:
+    branches: ["main"]
+
+# Declare default permissions as none.
+permissions: {}
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+    uses: sigstore/community/.github/workflows/reusable-scorecard.yml@d0c95c8803672313d0bf72e1a44021be5b583c24 # main
+    # (Optional) Disable publish results:
+    # with:
+    #   publish_results: false
+
+    # (Optional) Enable Branch-Protection check:
+    # secrets:
+    #   scorecard_token: ${{ secrets.SCORECARD_TOKEN }}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

The motivation for this PR is to make k8s-manifest-sigstore be warned about supply-chain security issues using Scorecard tool.
The PR adds Scorecard workflow using [sigstore/community reusable workflow](https://github.com/sigstore/community/blob/main/.github/workflows/reusable-scorecard.yml).
The PR does not add Scorecard badge to README, let me know if you would like that.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Config changes: Add Scorecard to warn about k8s-manifest-sigstore possible security issues

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
None.