### PR TITLE
fix SLSA goreleaser ldflags config to embed version info to executables

### DIFF
--- a/.github/workflows/slsa-goreleaser.yml
+++ b/.github/workflows/slsa-goreleaser.yml
@@ -37,7 +37,7 @@ jobs:
       contents: write # To upload assets to release.
       actions: read # To read the workflow path.
     needs: args
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v1.2.2
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v1.9.0
     with:
       config-file: .slsa-goreleaser-linux-amd64.yml
       go-version: 1.21
@@ -49,7 +49,7 @@ jobs:
       contents: write # To upload assets to release.
       actions: read # To read the workflow path.
     needs: args
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v1.2.2
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v1.9.0
     with:
       config-file: .slsa-goreleaser-darwin-amd64.yml
       go-version: 1.21
@@ -61,7 +61,7 @@ jobs:
       contents: write # To upload assets to release.
       actions: read # To read the workflow path.
     needs: args
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v1.2.2
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v1.9.0
     with:
       config-file: .slsa-goreleaser-windows-amd64.yml
       go-version: 1.21

--- a/.github/workflows/slsa-goreleaser.yml
+++ b/.github/workflows/slsa-goreleaser.yml
@@ -18,6 +18,7 @@ jobs:
       commit: ${{ steps.ldflags.outputs.commit }}
       version: ${{ steps.ldflags.outputs.version }}
       tree-state: ${{ steps.ldflags.outputs.tree-state }}
+      version-package: github.com/sigstore/k8s-manifest-sigstore/pkg/util
     steps:
       - id: checkout
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # tag=v2.3.4
@@ -41,7 +42,7 @@ jobs:
     with:
       config-file: .slsa-goreleaser-linux-amd64.yml
       go-version: 1.21
-      evaluated-envs: "COMMIT_DATE:${{needs.args.outputs.commit-date}}, COMMIT:${{needs.args.outputs.commit}}, VERSION:${{needs.args.outputs.version}}, TREE_STATE:${{needs.args.outputs.tree-state}}"
+      evaluated-envs: "COMMIT_DATE:${{needs.args.outputs.commit-date}}, COMMIT:${{needs.args.outputs.commit}}, VERSION:${{needs.args.outputs.version}}, TREE_STATE:${{needs.args.outputs.tree-state}}, VERSION_PKG:${{needs.args.outputs.version-package}}"
       
   build-darwin-amd64:
     permissions:
@@ -53,7 +54,7 @@ jobs:
     with:
       config-file: .slsa-goreleaser-darwin-amd64.yml
       go-version: 1.21
-      evaluated-envs: "COMMIT_DATE:${{needs.args.outputs.commit-date}}, COMMIT:${{needs.args.outputs.commit}}, VERSION:${{needs.args.outputs.version}}, TREE_STATE:${{needs.args.outputs.tree-state}}"
+      evaluated-envs: "COMMIT_DATE:${{needs.args.outputs.commit-date}}, COMMIT:${{needs.args.outputs.commit}}, VERSION:${{needs.args.outputs.version}}, TREE_STATE:${{needs.args.outputs.tree-state}}, VERSION_PKG:${{needs.args.outputs.version-package}}"
       
   build-windows-amd64:
     permissions:
@@ -65,5 +66,5 @@ jobs:
     with:
       config-file: .slsa-goreleaser-windows-amd64.yml
       go-version: 1.21
-      evaluated-envs: "COMMIT_DATE:${{needs.args.outputs.commit-date}}, COMMIT:${{needs.args.outputs.commit}}, VERSION:${{needs.args.outputs.version}}, TREE_STATE:${{needs.args.outputs.tree-state}}"
+      evaluated-envs: "COMMIT_DATE:${{needs.args.outputs.commit-date}}, COMMIT:${{needs.args.outputs.commit}}, VERSION:${{needs.args.outputs.version}}, TREE_STATE:${{needs.args.outputs.tree-state}}, VERSION_PKG:${{needs.args.outputs.version-package}}"
       

--- a/.slsa-goreleaser-darwin-amd64.yml
+++ b/.slsa-goreleaser-darwin-amd64.yml
@@ -30,7 +30,7 @@ binary: kubectl-sigstore-darwin-amd64
 
 # (Optional) ldflags generated dynamically in the workflow, and set as the `evaluated-envs` input variables in the workflow.
 ldflags:
-  - "-X main.Version={{ .Env.VERSION }}"
-  - "-X main.Commit={{ .Env.COMMIT }}"
-  - "-X main.CommitDate={{ .Env.COMMIT_DATE }}"
-  - "-X main.TreeState={{ .Env.TREE_STATE }}"
+  - "-X {{ .Env.VERSION_PKG }}.GitVersion={{ .Env.VERSION }}"
+  - "-X {{ .Env.VERSION_PKG }}.gitCommit={{ .Env.COMMIT }}"
+  - "-X {{ .Env.VERSION_PKG }}.buildDate={{ .Env.COMMIT_DATE }}"
+  - "-X {{ .Env.VERSION_PKG }}.gitTreeState={{ .Env.TREE_STATE }}"

--- a/.slsa-goreleaser-darwin-amd64.yml
+++ b/.slsa-goreleaser-darwin-amd64.yml
@@ -30,6 +30,7 @@ binary: kubectl-sigstore-darwin-amd64
 
 # (Optional) ldflags generated dynamically in the workflow, and set as the `evaluated-envs` input variables in the workflow.
 ldflags:
+  - "-s -w"
   - "-X {{ .Env.VERSION_PKG }}.GitVersion={{ .Env.VERSION }}"
   - "-X {{ .Env.VERSION_PKG }}.gitCommit={{ .Env.COMMIT }}"
   - "-X {{ .Env.VERSION_PKG }}.buildDate={{ .Env.COMMIT_DATE }}"

--- a/.slsa-goreleaser-darwin-amd64.yml
+++ b/.slsa-goreleaser-darwin-amd64.yml
@@ -30,4 +30,7 @@ binary: kubectl-sigstore-darwin-amd64
 
 # (Optional) ldflags generated dynamically in the workflow, and set as the `evaluated-envs` input variables in the workflow.
 ldflags:
-  - "\"-s -w -X {{ .Env.VERSION_PKG }}.GitVersion={{ .Env.VERSION }} -X {{ .Env.VERSION_PKG }}.gitCommit={{ .Env.COMMIT }} -X {{ .Env.VERSION_PKG }}.buildDate={{ .Env.COMMIT_DATE }} -X {{ .Env.VERSION_PKG }}.gitTreeState={{ .Env.TREE_STATE }}\""
+  - "-X '{{ .Env.VERSION_PKG }}.GitVersion={{ .Env.VERSION }}'"
+  - "-X '{{ .Env.VERSION_PKG }}.gitCommit={{ .Env.COMMIT }}'"
+  - "-X '{{ .Env.VERSION_PKG }}.buildDate={{ .Env.COMMIT_DATE }}'"
+  - "-X '{{ .Env.VERSION_PKG }}.gitTreeState={{ .Env.TREE_STATE }}'"

--- a/.slsa-goreleaser-darwin-amd64.yml
+++ b/.slsa-goreleaser-darwin-amd64.yml
@@ -30,8 +30,4 @@ binary: kubectl-sigstore-darwin-amd64
 
 # (Optional) ldflags generated dynamically in the workflow, and set as the `evaluated-envs` input variables in the workflow.
 ldflags:
-  - "-s -w"
-  - "-X {{ .Env.VERSION_PKG }}.GitVersion={{ .Env.VERSION }}"
-  - "-X {{ .Env.VERSION_PKG }}.gitCommit={{ .Env.COMMIT }}"
-  - "-X {{ .Env.VERSION_PKG }}.buildDate={{ .Env.COMMIT_DATE }}"
-  - "-X {{ .Env.VERSION_PKG }}.gitTreeState={{ .Env.TREE_STATE }}"
+  - "\"-s -w -X {{ .Env.VERSION_PKG }}.GitVersion={{ .Env.VERSION }} -X {{ .Env.VERSION_PKG }}.gitCommit={{ .Env.COMMIT }} -X {{ .Env.VERSION_PKG }}.buildDate={{ .Env.COMMIT_DATE }} -X {{ .Env.VERSION_PKG }}.gitTreeState={{ .Env.TREE_STATE }}\""

--- a/.slsa-goreleaser-linux-amd64.yml
+++ b/.slsa-goreleaser-linux-amd64.yml
@@ -30,4 +30,7 @@ binary: kubectl-sigstore-linux-{{ .Arch }}
 
 # (Optional) ldflags generated dynamically in the workflow, and set as the `evaluated-envs` input variables in the workflow.
 ldflags:
-  - "\"-s -w -X {{ .Env.VERSION_PKG }}.GitVersion={{ .Env.VERSION }} -X {{ .Env.VERSION_PKG }}.gitCommit={{ .Env.COMMIT }} -X {{ .Env.VERSION_PKG }}.buildDate={{ .Env.COMMIT_DATE }} -X {{ .Env.VERSION_PKG }}.gitTreeState={{ .Env.TREE_STATE }}\""
+  - "-X '{{ .Env.VERSION_PKG }}.GitVersion={{ .Env.VERSION }}'"
+  - "-X '{{ .Env.VERSION_PKG }}.gitCommit={{ .Env.COMMIT }}'"
+  - "-X '{{ .Env.VERSION_PKG }}.buildDate={{ .Env.COMMIT_DATE }}'"
+  - "-X '{{ .Env.VERSION_PKG }}.gitTreeState={{ .Env.TREE_STATE }}'"

--- a/.slsa-goreleaser-linux-amd64.yml
+++ b/.slsa-goreleaser-linux-amd64.yml
@@ -30,7 +30,7 @@ binary: kubectl-sigstore-linux-{{ .Arch }}
 
 # (Optional) ldflags generated dynamically in the workflow, and set as the `evaluated-envs` input variables in the workflow.
 ldflags:
-  - "-X main.Version={{ .Env.VERSION }}"
-  - "-X main.Commit={{ .Env.COMMIT }}"
-  - "-X main.CommitDate={{ .Env.COMMIT_DATE }}"
-  - "-X main.TreeState={{ .Env.TREE_STATE }}"
+  - "-X {{ .Env.VERSION_PKG }}.GitVersion={{ .Env.VERSION }}"
+  - "-X {{ .Env.VERSION_PKG }}.gitCommit={{ .Env.COMMIT }}"
+  - "-X {{ .Env.VERSION_PKG }}.buildDate={{ .Env.COMMIT_DATE }}"
+  - "-X {{ .Env.VERSION_PKG }}.gitTreeState={{ .Env.TREE_STATE }}"

--- a/.slsa-goreleaser-linux-amd64.yml
+++ b/.slsa-goreleaser-linux-amd64.yml
@@ -30,7 +30,4 @@ binary: kubectl-sigstore-linux-{{ .Arch }}
 
 # (Optional) ldflags generated dynamically in the workflow, and set as the `evaluated-envs` input variables in the workflow.
 ldflags:
-  - "-X {{ .Env.VERSION_PKG }}.GitVersion={{ .Env.VERSION }}"
-  - "-X {{ .Env.VERSION_PKG }}.gitCommit={{ .Env.COMMIT }}"
-  - "-X {{ .Env.VERSION_PKG }}.buildDate={{ .Env.COMMIT_DATE }}"
-  - "-X {{ .Env.VERSION_PKG }}.gitTreeState={{ .Env.TREE_STATE }}"
+  - "\"-s -w -X {{ .Env.VERSION_PKG }}.GitVersion={{ .Env.VERSION }} -X {{ .Env.VERSION_PKG }}.gitCommit={{ .Env.COMMIT }} -X {{ .Env.VERSION_PKG }}.buildDate={{ .Env.COMMIT_DATE }} -X {{ .Env.VERSION_PKG }}.gitTreeState={{ .Env.TREE_STATE }}\""

--- a/.slsa-goreleaser-windows-amd64.yml
+++ b/.slsa-goreleaser-windows-amd64.yml
@@ -30,4 +30,7 @@ binary: kubectl-sigstore-windows-amd64
 
 # (Optional) ldflags generated dynamically in the workflow, and set as the `evaluated-envs` input variables in the workflow.
 ldflags:
-  - "\"-s -w -X {{ .Env.VERSION_PKG }}.GitVersion={{ .Env.VERSION }} -X {{ .Env.VERSION_PKG }}.gitCommit={{ .Env.COMMIT }} -X {{ .Env.VERSION_PKG }}.buildDate={{ .Env.COMMIT_DATE }} -X {{ .Env.VERSION_PKG }}.gitTreeState={{ .Env.TREE_STATE }}\""
+  - "-X '{{ .Env.VERSION_PKG }}.GitVersion={{ .Env.VERSION }}'"
+  - "-X '{{ .Env.VERSION_PKG }}.gitCommit={{ .Env.COMMIT }}'"
+  - "-X '{{ .Env.VERSION_PKG }}.buildDate={{ .Env.COMMIT_DATE }}'"
+  - "-X '{{ .Env.VERSION_PKG }}.gitTreeState={{ .Env.TREE_STATE }}'"

--- a/.slsa-goreleaser-windows-amd64.yml
+++ b/.slsa-goreleaser-windows-amd64.yml
@@ -30,8 +30,7 @@ binary: kubectl-sigstore-windows-amd64
 
 # (Optional) ldflags generated dynamically in the workflow, and set as the `evaluated-envs` input variables in the workflow.
 ldflags:
-  - -buildmode=exe
-  - "-X main.Version={{ .Env.VERSION }}"
-  - "-X main.Commit={{ .Env.COMMIT }}"
-  - "-X main.CommitDate={{ .Env.COMMIT_DATE }}"
-  - "-X main.TreeState={{ .Env.TREE_STATE }}"
+  - "-X {{ .Env.VERSION_PKG }}.GitVersion={{ .Env.VERSION }}"
+  - "-X {{ .Env.VERSION_PKG }}.gitCommit={{ .Env.COMMIT }}"
+  - "-X {{ .Env.VERSION_PKG }}.buildDate={{ .Env.COMMIT_DATE }}"
+  - "-X {{ .Env.VERSION_PKG }}.gitTreeState={{ .Env.TREE_STATE }}"

--- a/.slsa-goreleaser-windows-amd64.yml
+++ b/.slsa-goreleaser-windows-amd64.yml
@@ -30,7 +30,4 @@ binary: kubectl-sigstore-windows-amd64
 
 # (Optional) ldflags generated dynamically in the workflow, and set as the `evaluated-envs` input variables in the workflow.
 ldflags:
-  - "-X {{ .Env.VERSION_PKG }}.GitVersion={{ .Env.VERSION }}"
-  - "-X {{ .Env.VERSION_PKG }}.gitCommit={{ .Env.COMMIT }}"
-  - "-X {{ .Env.VERSION_PKG }}.buildDate={{ .Env.COMMIT_DATE }}"
-  - "-X {{ .Env.VERSION_PKG }}.gitTreeState={{ .Env.TREE_STATE }}"
+  - "\"-s -w -X {{ .Env.VERSION_PKG }}.GitVersion={{ .Env.VERSION }} -X {{ .Env.VERSION_PKG }}.gitCommit={{ .Env.COMMIT }} -X {{ .Env.VERSION_PKG }}.buildDate={{ .Env.COMMIT_DATE }} -X {{ .Env.VERSION_PKG }}.gitTreeState={{ .Env.TREE_STATE }}\""


### PR DESCRIPTION
Signed-off-by: hirokuni-kitahara <hirokuni.kitahara1@ibm.com>

- fix SLSA goreleaser ldflags config to embed version info to executables

Issue solved by this PR: https://github.com/sigstore/k8s-manifest-sigstore/issues/102