### PR TITLE
ci: add permissions: contents: read to cross

### DIFF
--- a/.github/workflows/cross.yaml
+++ b/.github/workflows/cross.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
 
 name: Cross Platfrom Build
+permissions:
+  contents: read
+
 jobs:
   sanity-build:
     name: build


### PR DESCRIPTION
Sets the minimum-required `GITHUB_TOKEN` scope on `cross.yaml`:

- Workflow-level `permissions:` -> `contents: read`
- No changes to jobs, steps, runners, or triggers
- YAML still parses (`yaml.safe_load` succeeds)

Rationale:

- The cross-platform build job is read-only; nothing in it needs write access to the repo.
- Without an explicit block, the run inherits whatever default the repository's actions settings happen to be set to. That default has drifted in the past, and forks-of-forks lose track of it.
- the OpenSSF Scorecard Token-Permissions check flags missing per-workflow permissions as a finding.
- After the tj-actions/changed-files supply-chain incident from March 2025, the cost-benefit on explicit minimum scopes is firmly on the side of declaring them.
